### PR TITLE
feat: auto-detect repository from Quarto project repo-url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+- feat: Auto-detect repository from Quarto project `repo-url` for website and book projects.
+
 ## 1.3.0 (2026-03-23)
 
 ### Refactoring

--- a/README.md
+++ b/README.md
@@ -157,13 +157,45 @@ The extension automatically processes full URLs and converts them to short refer
 
 ### Repository Detection
 
-If `repository-name` is not specified, the extension auto-detects from git remote:
+The extension resolves the repository URL using the following priority order:
 
-```bash
-git remote get-url origin
-```
+1. **Explicit configuration** (highest priority): Set `repository-name`, `platform`, and `base-url` directly in the document or project metadata.
 
-Supports: `https://github.com/owner/repo.git`, `git@gitlab.com:group/project.git`, `ssh://git@codeberg.org/user/repo.git`
+   ```yaml
+   extensions:
+     gitlink:
+       platform: github
+       base-url: https://github.com
+       repository-name: owner/repo
+   ```
+
+2. **Quarto project `repo-url`**: For website or book projects, the extension reads `repo-url` from the project configuration (`_quarto.yml`). The platform, base URL, and repository name are all auto-detected from the full URL.
+
+   ```yaml
+   # _quarto.yml
+   website:
+     repo-url: https://github.com/owner/repo
+   ```
+
+   This also works with `book` projects:
+
+   ```yaml
+   # _quarto.yml
+   book:
+     repo-url: https://gitlab.com/group/project
+   ```
+
+   > [!NOTE]
+   > When using `repo-url`, the platform is auto-detected from the URL.
+   > You can still override individual values (e.g., set `platform` explicitly) while letting the rest be auto-detected.
+
+3. **Git remote** (lowest priority): If neither of the above is available, the extension falls back to detecting the repository from the git remote origin URL.
+
+   ```bash
+   git remote get-url origin
+   ```
+
+   Supports: `https://github.com/owner/repo.git`, `git@gitlab.com:group/project.git`, `ssh://git@codeberg.org/user/repo.git`.
 
 ### Platform Badges
 

--- a/_extensions/gitlink/_modules/metadata.lua
+++ b/_extensions/gitlink/_modules/metadata.lua
@@ -176,6 +176,44 @@ function M.get_options(spec)
 end
 
 -- ============================================================================
+-- PROJECT METADATA UTILITIES
+-- ============================================================================
+
+--- Get repo-url from Quarto project metadata via QUARTO_EXECUTE_INFO.
+--- Reads the JSON file pointed to by the QUARTO_EXECUTE_INFO environment variable
+--- and extracts repo-url from website or book metadata.
+--- @return string|nil The repo-url value, or nil if not available
+function M.get_project_repo_url()
+  local path = os.getenv("QUARTO_EXECUTE_INFO")
+  if not path then return nil end
+
+  local file = io.open(path, "r")
+  if not file then return nil end
+
+  local content = file:read("*a")
+  file:close()
+
+  if str.is_empty(content) then return nil end
+
+  local ok, info = pcall(quarto.json.decode, content)
+  if not ok or not info then return nil end
+
+  local format_meta = info["format"] and info["format"]["metadata"]
+  if not format_meta then return nil end
+
+  -- Try website.repo-url first, then book.repo-url
+  local repo_url = nil
+  if format_meta["website"] and format_meta["website"]["repo-url"] then
+    repo_url = format_meta["website"]["repo-url"]
+  elseif format_meta["book"] and format_meta["book"]["repo-url"] then
+    repo_url = format_meta["book"]["repo-url"]
+  end
+
+  if str.is_empty(repo_url) then return nil end
+  return repo_url
+end
+
+-- ============================================================================
 -- MODULE EXPORT
 -- ============================================================================
 

--- a/_extensions/gitlink/gitlink.lua
+++ b/_extensions/gitlink/gitlink.lua
@@ -207,6 +207,13 @@ local function get_repository(meta)
   local parsed_platform, parsed_base_url, parsed_repo_name = nil, nil, nil
   if project_repo_url then
     parsed_platform, parsed_base_url, parsed_repo_name = parse_repo_url(project_repo_url)
+    if not parsed_platform then
+      log.log_warning(
+        EXTENSION_NAME,
+        "Could not match project repo-url '" .. project_repo_url ..
+        "' to any known platform. Falling back to default resolution."
+      )
+    end
   end
 
   -- Resolve platform: explicit metadata > repo-url detection > default 'github'

--- a/_extensions/gitlink/gitlink.lua
+++ b/_extensions/gitlink/gitlink.lua
@@ -70,8 +70,11 @@ local function parse_repo_url(url)
       local escaped = str.escape_pattern(config.base_url)
       local repo_path = url:match('^' .. escaped .. '/(.+)$')
       if repo_path then
+        repo_path = repo_path:match('^([^%?#]+)') or repo_path
         repo_path = repo_path:gsub('%.git$', ''):gsub('/$', '')
-        return name, config.base_url, repo_path
+        if not str.is_empty(repo_path) then
+          return name, config.base_url, repo_path
+        end
       end
     end
   end

--- a/_extensions/gitlink/gitlink.lua
+++ b/_extensions/gitlink/gitlink.lua
@@ -56,6 +56,28 @@ local function get_platform_config(platform_name)
   return platforms.get_platform_config(platform_name:lower())
 end
 
+--- Parse a full repository URL to extract platform, base-url, and owner/repo.
+--- Matches the URL against all known platform base URLs.
+--- @param url string The full repository URL (e.g., "https://github.com/owner/repo")
+--- @return string|nil platform_name The matched platform name
+--- @return string|nil matched_base_url The base URL portion
+--- @return string|nil repo_path The owner/repo portion
+local function parse_repo_url(url)
+  local all_names = platforms.get_all_platform_names()
+  for _, name in ipairs(all_names) do
+    local config = platforms.get_platform_config(name)
+    if config and config.base_url then
+      local escaped = str.escape_pattern(config.base_url)
+      local repo_path = url:match('^' .. escaped .. '/(.+)$')
+      if repo_path then
+        repo_path = repo_path:gsub('%.git$', ''):gsub('/$', '')
+        return name, config.base_url, repo_path
+      end
+    end
+  end
+  return nil, nil, nil
+end
+
 --- Create a link with platform label
 --- @param text string|nil The link text
 --- @param uri string|nil The URI
@@ -177,11 +199,22 @@ local function get_repository(meta)
     end
   end
 
+  -- Parse repo-url from project metadata (website/book)
+  local project_repo_url = meta_mod.get_project_repo_url()
+  local parsed_platform, parsed_base_url, parsed_repo_name = nil, nil, nil
+  if project_repo_url then
+    parsed_platform, parsed_base_url, parsed_repo_name = parse_repo_url(project_repo_url)
+  end
+
+  -- Resolve platform: explicit metadata > repo-url detection > default 'github'
   if not str.is_empty(meta_platform) then
     platform = (meta_platform --[[@as string]]):lower()
+  elseif parsed_platform then
+    platform = parsed_platform
   else
     platform = 'github'
   end
+
   local config = get_platform_config(platform)
   if not config then
     local available_platforms = table.concat(platforms.get_all_platform_names(), ', ')
@@ -193,17 +226,23 @@ local function get_repository(meta)
     return meta
   end
 
+  -- Resolve base-url: explicit metadata > repo-url detection > platform default
   if not str.is_empty(meta_base_url) then
     base_url = meta_base_url --[[@as string]]
+  elseif parsed_base_url then
+    base_url = parsed_base_url
   else
     base_url = config.base_url
   end
 
-  if str.is_empty(meta_repository) then
-    meta_repository = git.get_repository()
+  -- Resolve repository-name: explicit metadata > repo-url path > git remote
+  if not str.is_empty(meta_repository) then
+    repository_name = meta_repository
+  elseif parsed_repo_name then
+    repository_name = parsed_repo_name
+  else
+    repository_name = git.get_repository()
   end
-
-  repository_name = meta_repository
 
   local show_badge_meta = meta_mod.get_metadata_value(meta, 'gitlink', 'show-platform-badge')
   if show_badge_meta ~= nil then


### PR DESCRIPTION
Reads repo-url from website or book project metadata (via QUARTO_EXECUTE_INFO) to auto-detect the platform, base URL, and repository name.
This allows website and book projects that already define repo-url in _quarto.yml to use gitlink without any additional configuration.

Resolution priority: explicit extensions.gitlink config > project repo-url > git remote.