### PR TITLE
feat: support references surrounded by parentheses and punctuation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+- feat: Support references surrounded by parentheses, brackets, quotes, and trailing punctuation.
+
 ## 1.4.0 (2026-04-09)
 
 ### New Features

--- a/_extensions/gitlink/_modules/bitbucket.lua
+++ b/_extensions/gitlink/_modules/bitbucket.lua
@@ -4,6 +4,8 @@
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil
 
+local str = require("_modules/string")
+
 local bitbucket_module = {}
 
 -- ============================================================================
@@ -17,6 +19,28 @@ local bitbucket_module = {}
 --- @return pandoc.Link A Pandoc Link element with platform label
 local function create_bitbucket_link(text, uri, create_link_fn)
   return create_link_fn(text, uri, "bitbucket")
+end
+
+--- Try matching a Str element's text against a pattern, with stripping fallback.
+--- @param elem_text string The text to match
+--- @param pattern string The Lua pattern (anchored with ^ and $)
+--- @return string|nil prefix Stripped prefix (empty if direct match)
+--- @return string|nil ... Captures from the pattern match
+--- @return string|nil suffix Stripped suffix (empty if direct match)
+local function match_with_stripping(elem_text, pattern)
+  local captures = { elem_text:match("^" .. pattern .. "$") }
+  if #captures > 0 then
+    return "", captures, ""
+  end
+  local prefix, inner, suffix = str.strip_surrounding(elem_text)
+  if (prefix == "" and suffix == "") or inner == "" then
+    return nil, nil, nil
+  end
+  captures = { inner:match("^" .. pattern .. "$") }
+  if #captures > 0 then
+    return prefix, captures, suffix
+  end
+  return nil, nil, nil
 end
 
 -- ============================================================================
@@ -44,19 +68,24 @@ function bitbucket_module.process_inlines(inlines, base_url, repository_name, cr
       local elem1, elem2, elem3 = inlines[i], inlines[i + 1], inlines[i + 2]
       if elem1.t == "Str" and elem1.text == "issue" and
           elem2.t == "Space" and
-          elem3.t == "Str" and elem3.text:match("^#(%d+)$") then
-        local number = elem3.text:match("^#(%d+)$")
-        local uri
-        if repository_name then
-          uri = base_url .. "/" .. repository_name .. "/issues/" .. number
-        else
-          return inlines
-        end
-        local link = create_bitbucket_link("issue " .. elem3.text, uri, create_link_fn)
-        if link then
-          table.insert(result, link)
-          i = i + 3
-          matched = true
+          elem3.t == "Str" then
+        local prefix, captures, suffix = match_with_stripping(elem3.text, "#(%d+)")
+        if captures then
+          local number = captures[1]
+          local uri
+          if repository_name then
+            uri = base_url .. "/" .. repository_name .. "/issues/" .. number
+          else
+            return inlines
+          end
+          local link = create_bitbucket_link("issue #" .. number, uri, create_link_fn)
+          if link then
+            if prefix ~= "" then table.insert(result, pandoc.Str(prefix)) end
+            table.insert(result, link)
+            if suffix ~= "" then table.insert(result, pandoc.Str(suffix)) end
+            i = i + 3
+            matched = true
+          end
         end
       end
     end
@@ -66,14 +95,19 @@ function bitbucket_module.process_inlines(inlines, base_url, repository_name, cr
       local elem1, elem2, elem3 = inlines[i], inlines[i + 1], inlines[i + 2]
       if elem1.t == "Str" and elem1.text == "issue" and
           elem2.t == "Space" and
-          elem3.t == "Str" and elem3.text:match("^([^/]+/[^/#]+)#(%d+)$") then
-        local repo, number = elem3.text:match("^([^/]+/[^/#]+)#(%d+)$")
-        local uri = base_url .. "/" .. repo .. "/issues/" .. number
-        local link = create_bitbucket_link("issue " .. elem3.text, uri, create_link_fn)
-        if link then
-          table.insert(result, link)
-          i = i + 3
-          matched = true
+          elem3.t == "Str" then
+        local prefix, captures, suffix = match_with_stripping(elem3.text, "([^/]+/[^/#]+)#(%d+)")
+        if captures then
+          local repo, number = captures[1], captures[2]
+          local uri = base_url .. "/" .. repo .. "/issues/" .. number
+          local link = create_bitbucket_link("issue " .. repo .. "#" .. number, uri, create_link_fn)
+          if link then
+            if prefix ~= "" then table.insert(result, pandoc.Str(prefix)) end
+            table.insert(result, link)
+            if suffix ~= "" then table.insert(result, pandoc.Str(suffix)) end
+            i = i + 3
+            matched = true
+          end
         end
       end
     end
@@ -85,19 +119,24 @@ function bitbucket_module.process_inlines(inlines, base_url, repository_name, cr
           elem2.t == "Space" and
           elem3.t == "Str" and elem3.text == "request" and
           elem4.t == "Space" and
-          elem5.t == "Str" and elem5.text:match("^#(%d+)$") then
-        local number = elem5.text:match("^#(%d+)$")
-        local uri
-        if repository_name then
-          uri = base_url .. "/" .. repository_name .. "/pull-requests/" .. number
-        else
-          return inlines
-        end
-        local link = create_bitbucket_link("pull request " .. elem5.text, uri, create_link_fn)
-        if link then
-          table.insert(result, link)
-          i = i + 5
-          matched = true
+          elem5.t == "Str" then
+        local prefix, captures, suffix = match_with_stripping(elem5.text, "#(%d+)")
+        if captures then
+          local number = captures[1]
+          local uri
+          if repository_name then
+            uri = base_url .. "/" .. repository_name .. "/pull-requests/" .. number
+          else
+            return inlines
+          end
+          local link = create_bitbucket_link("pull request #" .. number, uri, create_link_fn)
+          if link then
+            if prefix ~= "" then table.insert(result, pandoc.Str(prefix)) end
+            table.insert(result, link)
+            if suffix ~= "" then table.insert(result, pandoc.Str(suffix)) end
+            i = i + 5
+            matched = true
+          end
         end
       end
     end
@@ -109,14 +148,19 @@ function bitbucket_module.process_inlines(inlines, base_url, repository_name, cr
           elem2.t == "Space" and
           elem3.t == "Str" and elem3.text == "request" and
           elem4.t == "Space" and
-          elem5.t == "Str" and elem5.text:match("^([^/]+/[^/#]+)#(%d+)$") then
-        local repo, number = elem5.text:match("^([^/]+/[^/#]+)#(%d+)$")
-        local uri = base_url .. "/" .. repo .. "/pull-requests/" .. number
-        local link = create_bitbucket_link("pull request " .. elem5.text, uri, create_link_fn)
-        if link then
-          table.insert(result, link)
-          i = i + 5
-          matched = true
+          elem5.t == "Str" then
+        local prefix, captures, suffix = match_with_stripping(elem5.text, "([^/]+/[^/#]+)#(%d+)")
+        if captures then
+          local repo, number = captures[1], captures[2]
+          local uri = base_url .. "/" .. repo .. "/pull-requests/" .. number
+          local link = create_bitbucket_link("pull request " .. repo .. "#" .. number, uri, create_link_fn)
+          if link then
+            if prefix ~= "" then table.insert(result, pandoc.Str(prefix)) end
+            table.insert(result, link)
+            if suffix ~= "" then table.insert(result, pandoc.Str(suffix)) end
+            i = i + 5
+            matched = true
+          end
         end
       end
     end

--- a/_extensions/gitlink/_modules/string.lua
+++ b/_extensions/gitlink/_modules/string.lua
@@ -57,6 +57,47 @@ function M.trim(str)
   return str:match('^%s*(.-)%s*$')
 end
 
+--- Strip one layer of surrounding bracket or punctuation characters.
+--- Handles balanced pairs: () [] {} "" '' `` «»
+--- Handles trailing-only punctuation: , . ; : ! ?
+--- @param text string The input text
+--- @return string prefix Characters stripped from the start (may be empty)
+--- @return string inner The inner text after stripping
+--- @return string suffix Characters stripped from the end (may be empty)
+function M.strip_surrounding(text)
+  if not text or #text < 2 then
+    return "", text or "", ""
+  end
+
+  local balanced = {
+    ["("] = ")", ["["] = "]", ["{"] = "}",
+    ['"'] = '"', ["'"] = "'", ["`"] = "`",
+  }
+  -- UTF-8 guillemets
+  local first_two = text:sub(1, 2)
+  local last_two = text:sub(-2)
+  if first_two == "\xC2\xAB" and last_two == "\xC2\xBB" then
+    return first_two, text:sub(3, -3), last_two
+  end
+
+  local first = text:sub(1, 1)
+  local last = text:sub(-1)
+
+  if balanced[first] and last == balanced[first] then
+    return first, text:sub(2, -2), last
+  end
+
+  local trailing = {
+    [","] = true, ["."] = true, [";"] = true,
+    [":"] = true, ["!"] = true, ["?"] = true,
+  }
+  if trailing[last] then
+    return "", text:sub(1, -2), last
+  end
+
+  return "", text, ""
+end
+
 --- Convert any value to a string, handling Pandoc objects and empty values.
 --- Returns nil for empty or nil values, otherwise returns a string representation.
 --- @param val any The value to convert

--- a/_extensions/gitlink/gitlink.lua
+++ b/_extensions/gitlink/gitlink.lua
@@ -578,31 +578,45 @@ end
 --- Main Git hosting processing function
 --- Attempts to convert string elements into Git hosting links by trying different patterns
 --- @param elem pandoc.Str The string element to process
---- @return pandoc.Str|pandoc.Link The original element or a Git hosting link
+--- @return pandoc.Str|pandoc.Link|pandoc.List The original element, a link, or a list of inlines
 local function process_gitlink(elem)
   if not platform or not base_url or str.is_empty(platform) then
     return elem
   end
 
-  local link = nil
+  -- Fast path: try matching the raw text directly
+  local link = process_issues_and_mrs(elem, platform, base_url)
+    or process_commits(elem, platform, base_url)
+    or process_users(elem, platform)
 
-  if link == nil then
-    link = process_issues_and_mrs(elem, platform, base_url)
-  end
-
-  if link == nil then
-    link = process_commits(elem, platform, base_url)
-  end
-
-  if link == nil then
-    link = process_users(elem, platform)
-  end
-
-  if link == nil then
-    return elem
-  else
+  if link then
     return link
   end
+
+  -- Slow path: strip one layer of surrounding punctuation and retry
+  local prefix, inner, suffix = str.strip_surrounding(elem.text)
+  if (prefix == "" and suffix == "") or inner == "" then
+    return elem
+  end
+
+  local inner_elem = pandoc.Str(inner)
+  link = process_issues_and_mrs(inner_elem, platform, base_url)
+    or process_commits(inner_elem, platform, base_url)
+    or process_users(inner_elem, platform)
+
+  if link then
+    local result = pandoc.List({})
+    if prefix ~= "" then
+      result:insert(pandoc.Str(prefix))
+    end
+    result:insert(link)
+    if suffix ~= "" then
+      result:insert(pandoc.Str(suffix))
+    end
+    return result
+  end
+
+  return elem
 end
 
 --- Process inline elements for Bitbucket multi-word patterns

--- a/example.qmd
+++ b/example.qmd
@@ -83,6 +83,18 @@ Reference issues and pull requests:
 - User mention: @mcanouil
 - GitHub-style issue: GH-1
 
+References with surrounding characters:
+
+- Parenthesised issue: (#1)
+- Parenthesised user: (@mcanouil)
+- Square brackets: [#1]
+- Curly braces: {#1}
+- Double quotes: "#1"
+- Trailing comma: #1,
+- Trailing period: #1.
+- Parenthesised commit: (cb0350d0316d1c420508338d02e56f5c8f907226)
+- Realistic changelog: fix: this is fixed (#1) (by @mcanouil)
+
 Full URL examples (automatically shortened):
 
 - Issue URL: <https://github.com/mcanouil/quarto-gitlink/issues/1>


### PR DESCRIPTION
References like `#123`, `@user`, and commit SHAs are now recognised when surrounded by parentheses, square brackets, curly braces, quotes, or guillemets, and when followed by trailing punctuation (comma, period, semicolon, colon, exclamation, question mark).

One layer of surrounding characters is stripped before pattern matching, so text like `fix: this is fixed (#123) (by @someone)` produces working links for both `#123` and `@someone`. The same stripping is applied in the Bitbucket multi-word pattern handler.