### PR TITLE
fix: recognise references inside brackets with surrounding text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- fix: Recognise references inside bracket pairs surrounded by additional text or punctuation, e.g. `something(#1)`, `(#1).`, `.(#1).`, `(mcanouil/quarto-gitlink#1)something`.
+
 ## 1.5.1 (2026-04-15)
 
 ### Refactoring

--- a/_extensions/gitlink/_modules/bitbucket.lua
+++ b/_extensions/gitlink/_modules/bitbucket.lua
@@ -32,14 +32,28 @@ local function match_with_stripping(elem_text, pattern)
   if #captures > 0 then
     return "", captures, ""
   end
+
   local prefix, inner, suffix = str.strip_surrounding(elem_text)
-  if (prefix == "" and suffix == "") or inner == "" then
-    return nil, nil, nil
+  if (prefix ~= "" or suffix ~= "") and inner ~= "" then
+    captures = { inner:match("^" .. pattern .. "$") }
+    if #captures > 0 then
+      return prefix, captures, suffix
+    end
   end
-  captures = { inner:match("^" .. pattern .. "$") }
-  if #captures > 0 then
-    return prefix, captures, suffix
+
+  local search_pos = 1
+  while true do
+    local b_prefix, b_content, b_suffix, open_pos = str.find_bracketed_content(elem_text, search_pos)
+    if not b_content then
+      break
+    end
+    captures = { b_content:match("^" .. pattern .. "$") }
+    if #captures > 0 then
+      return b_prefix, captures, b_suffix
+    end
+    search_pos = open_pos + 1
   end
+
   return nil, nil, nil
 end
 

--- a/_extensions/gitlink/_modules/string.lua
+++ b/_extensions/gitlink/_modules/string.lua
@@ -98,6 +98,55 @@ function M.strip_surrounding(text)
   return "", text, ""
 end
 
+--- Find a balanced bracket pair anywhere in the text and split around it.
+--- Walks the text from `start_pos` looking for an opening bracket whose matching
+--- closing bracket appears later in the string. Returns the text split into
+--- a prefix (up to and including the opening bracket), the inner content, and
+--- a suffix (closing bracket and everything after).
+--- Supports the same bracket pairs as `strip_surrounding`:
+--- () [] {} "" '' `` and the 2-byte UTF-8 guillemets «».
+--- @param text string The input text
+--- @param start_pos integer|nil Byte position to start searching from (default 1)
+--- @return string|nil prefix Text up to and including the opening bracket
+--- @return string|nil content Non-empty text between the brackets
+--- @return string|nil suffix Closing bracket and trailing text
+--- @return integer|nil open_pos Byte position of the opening bracket
+function M.find_bracketed_content(text, start_pos)
+  if not text or #text < 2 then
+    return nil, nil, nil, nil
+  end
+  start_pos = start_pos or 1
+
+  local balanced = {
+    ["("] = ")", ["["] = "]", ["{"] = "}",
+    ['"'] = '"', ["'"] = "'", ["`"] = "`",
+  }
+
+  local i = start_pos
+  while i <= #text do
+    -- UTF-8 guillemet «…»
+    if text:sub(i, i + 1) == "\xC2\xAB" then
+      local close_pos = text:find("\xC2\xBB", i + 2, true)
+      if close_pos and close_pos > i + 2 then
+        return text:sub(1, i + 1), text:sub(i + 2, close_pos - 1), text:sub(close_pos), i
+      end
+      i = i + 2
+    else
+      local c = text:sub(i, i)
+      local close_char = balanced[c]
+      if close_char then
+        local close_pos = text:find(close_char, i + 1, true)
+        if close_pos and close_pos > i + 1 then
+          return text:sub(1, i), text:sub(i + 1, close_pos - 1), text:sub(close_pos), i
+        end
+      end
+      i = i + 1
+    end
+  end
+
+  return nil, nil, nil, nil
+end
+
 --- Convert any value to a string, handling Pandoc objects and empty values.
 --- Returns nil for empty or nil values, otherwise returns a string representation.
 --- @param val any The value to convert

--- a/_extensions/gitlink/gitlink.lua
+++ b/_extensions/gitlink/gitlink.lua
@@ -595,25 +595,56 @@ local function process_gitlink(elem)
 
   -- Slow path: strip one layer of surrounding punctuation and retry
   local prefix, inner, suffix = str.strip_surrounding(elem.text)
-  if (prefix == "" and suffix == "") or inner == "" then
-    return elem
+  if prefix ~= "" or suffix ~= "" then
+    if inner ~= "" then
+      local inner_elem = pandoc.Str(inner)
+      link = process_issues_and_mrs(inner_elem, platform, base_url)
+        or process_commits(inner_elem, platform, base_url)
+        or process_users(inner_elem, platform)
+
+      if link then
+        local result = pandoc.List({})
+        if prefix ~= "" then
+          result:insert(pandoc.Str(prefix))
+        end
+        result:insert(link)
+        if suffix ~= "" then
+          result:insert(pandoc.Str(suffix))
+        end
+        return result
+      end
+    end
   end
 
-  local inner_elem = pandoc.Str(inner)
-  link = process_issues_and_mrs(inner_elem, platform, base_url)
-    or process_commits(inner_elem, platform, base_url)
-    or process_users(inner_elem, platform)
+  -- Embedded path: scan for a bracket pair anywhere inside the token and
+  -- retry the matchers on the bracket content. Handles cases where the
+  -- bracket is surrounded by additional text or punctuation, e.g.
+  -- "something(#1)", "(#1).", ".(#1).", "(#1)something".
+  local search_pos = 1
+  while true do
+    local b_prefix, b_content, b_suffix, open_pos = str.find_bracketed_content(elem.text, search_pos)
+    if not b_content then
+      break
+    end
 
-  if link then
-    local result = pandoc.List({})
-    if prefix ~= "" then
-      result:insert(pandoc.Str(prefix))
+    local content_elem = pandoc.Str(b_content)
+    local content_link = process_issues_and_mrs(content_elem, platform, base_url)
+      or process_commits(content_elem, platform, base_url)
+      or process_users(content_elem, platform)
+
+    if content_link then
+      local result = pandoc.List({})
+      if b_prefix ~= "" then
+        result:insert(pandoc.Str(b_prefix))
+      end
+      result:insert(content_link)
+      if b_suffix ~= "" then
+        result:insert(pandoc.Str(b_suffix))
+      end
+      return result
     end
-    result:insert(link)
-    if suffix ~= "" then
-      result:insert(pandoc.Str(suffix))
-    end
-    return result
+
+    search_pos = open_pos + 1
   end
 
   return elem

--- a/example.qmd
+++ b/example.qmd
@@ -94,6 +94,15 @@ References with surrounding characters:
 - Trailing period: #1.
 - Parenthesised commit: (cb0350d0316d1c420508338d02e56f5c8f907226)
 - Realistic changelog: fix: this is fixed (#1) (by @mcanouil)
+- Bracket with trailing punctuation: (#1).
+- Bracket with leading punctuation: .(#1)
+- Bracket with both leading and trailing punctuation: .(#1).
+- Bracket with leading text: something(#1)
+- Bracket with trailing text: (#1)something
+- Bracket with leading and trailing text: something(#1)something
+- Bracket with cross-repository issue and trailing text: (mcanouil/quarto-gitlink#1)something
+- Bracket with GitHub-style issue and surrounding text: see(GH-1)now
+- Bracket with commit and trailing punctuation: see(cb0350d0316d1c420508338d02e56f5c8f907226).
 
 Full URL examples (automatically shortened):
 


### PR DESCRIPTION
Recognise Git hosting references when they appear inside a bracket pair that is itself surrounded by additional text or punctuation in the same Pandoc `Str` token, such as `something(#1)`, `(#1).`, `.(#1).`, `(mcanouil/quarto-gitlink#1)something` or `see(cb0350d).`.

The previous behaviour only stripped one outer layer (a balanced bracket pair OR a single trailing punctuation character), so the bracket pair had to sit at the very ends of the token to be recognised. A new `find_bracketed_content` helper scans the token for the first balanced bracket pair anywhere inside it and re-runs the existing matchers on the bracket content, emitting the surrounding prefix and suffix as plain `Str` siblings. The same helper is reused by the Bitbucket multi-word matcher so every reference type (issue, merge request, GH-style, cross-repository, commit SHA, user mention and full URL) recovers in the same shapes.