### PR TITLE
feat: v1.6.0 review fixes and new options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 *_files/
 /.luarc.json
 /.quarto/
+/.tmp-tests/
 **/*.quarto_ipynb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-## 1.6.0 (2026-05-28)
-
 ### New Features
 
 - feat: Add `gitlink.enabled` option so drafts and templates can opt out of link rewriting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+## 1.6.0 (2026-05-28)
+
+### New Features
+
+- feat: Add `gitlink.enabled` option so drafts and templates can opt out of link rewriting.
+- feat: Add `gitlink.normalize-links` option to toggle URL shortening of autolinked platform URLs.
+- feat: Add `gitlink.fetch-titles` option to use the page title of an autolinked platform URL as the link text (best-effort via `curl`).
+- feat: Add `gitlink.mentions` list to force-treat specific citation IDs as Git hosting mentions even when a bibliography reference with the same id exists.
+
+### Bug Fixes
+
+- fix: Validate `badge-background-colour` and `badge-text-colour` against hex codes and CSS named colours; invalid values are now warned and ignored instead of producing broken inline styles or invalid Typst `rgb()` calls.
+- fix: Reject cross-repository commit references (`owner/repo@<sha>`) whose SHA is shorter than 7 or longer than 40 hexadecimal characters; previously over-length SHAs produced an incorrect link.
+- fix: Reset module-level state at the start of each document so batch renders no longer leak platform, repository, badge, or reference-set state across documents.
+- fix: Respect boolean `false` for `show-platform-badge`, `enabled`, and `normalize-links` (the previous metadata accessor treated `false` as missing).
+
+### Refactoring
+
+- refactor: Cache platform-config lookups per render to avoid repeated module calls on every Str element.
+- refactor: Add canonical `colour.lua` shared module for hex/named colour validation.
+
 ## 1.5.2 (2026-04-17)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A Quarto extension that automatically converts Git hosting platform references (
 ## Installation
 
 ```bash
-quarto add mcanouil/quarto-gitlink@1.5.2
+quarto add mcanouil/quarto-gitlink@1.6.0
 ```
 
 This will install the extension under the `_extensions` subdirectory.
@@ -154,6 +154,45 @@ The extension automatically processes full URLs and converts them to short refer
 
 > [!TIP]
 > Wrap URLs in angle brackets (`<URL>`) for best results instead of bare URLs.
+
+You can opt out of URL shortening with `normalize-links: false`:
+
+```yaml
+extensions:
+  gitlink:
+    normalize-links: false   # leave autolinked URLs as-is (default: true)
+```
+
+You can also have the extension fetch the page title of an autolinked platform URL and use it as the link text (best-effort via `curl`):
+
+```yaml
+extensions:
+  gitlink:
+    fetch-titles: true   # default: false; requires network access
+```
+
+### Drafts and Templates
+
+To opt out of all link rewriting for a single document (for example, in a draft or template), set:
+
+```yaml
+extensions:
+  gitlink:
+    enabled: false
+```
+
+### Citations vs. Mentions
+
+When a Quarto bibliography contains an entry whose id matches a Git hosting username (for example, both `@mcanouil` the user and a `@mcanouil` citation), Pandoc treats the token as a citation and Gitlink leaves it alone.
+You can force-treat selected citation IDs as Git hosting mentions with:
+
+```yaml
+extensions:
+  gitlink:
+    mentions:
+      - mcanouil
+      - other-username
+```
 
 ### Repository Detection
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A Quarto extension that automatically converts Git hosting platform references (
 ## Installation
 
 ```bash
-quarto add mcanouil/quarto-gitlink@1.6.0
+quarto add mcanouil/quarto-gitlink@1.5.2
 ```
 
 This will install the extension under the `_extensions` subdirectory.

--- a/_extensions/gitlink/_extension.yml
+++ b/_extensions/gitlink/_extension.yml
@@ -1,6 +1,6 @@
 title: gitlink
 author: Mickaël Canouil
-version: 1.5.2
+version: 1.6.0
 quarto-required: ">=1.8.21"
 contributes:
   filters:

--- a/_extensions/gitlink/_extension.yml
+++ b/_extensions/gitlink/_extension.yml
@@ -1,6 +1,6 @@
 title: gitlink
 author: Mickaël Canouil
-version: 1.6.0
+version: 1.5.2
 quarto-required: ">=1.8.21"
 contributes:
   filters:

--- a/_extensions/gitlink/_modules/colour.lua
+++ b/_extensions/gitlink/_modules/colour.lua
@@ -1,0 +1,369 @@
+--- MC Colour - Colour conversion utilities for Quarto Lua filters and shortcodes
+--- @module "colour"
+--- @license MIT
+--- @copyright 2026 Mickaël Canouil
+--- @author Mickaël Canouil
+--- @version 1.0.0
+
+local M = {}
+
+-- ============================================================================
+-- CSS NAMED COLOURS
+-- ============================================================================
+
+--- CSS named colours lookup table.
+--- Maps lowercase colour names to uppercase 6-character hex codes.
+--- Contains all 148 standard CSS named colours.
+--- @type table<string, string>
+local CSS_NAMED_COLOURS = {
+  aliceblue = '#F0F8FF',
+  antiquewhite = '#FAEBD7',
+  aqua = '#00FFFF',
+  aquamarine = '#7FFFD4',
+  azure = '#F0FFFF',
+  beige = '#F5F5DC',
+  bisque = '#FFE4C4',
+  black = '#000000',
+  blanchedalmond = '#FFEBCD',
+  blue = '#0000FF',
+  blueviolet = '#8A2BE2',
+  brown = '#A52A2A',
+  burlywood = '#DEB887',
+  cadetblue = '#5F9EA0',
+  chartreuse = '#7FFF00',
+  chocolate = '#D2691E',
+  coral = '#FF7F50',
+  cornflowerblue = '#6495ED',
+  cornsilk = '#FFF8DC',
+  crimson = '#DC143C',
+  cyan = '#00FFFF',
+  darkblue = '#00008B',
+  darkcyan = '#008B8B',
+  darkgoldenrod = '#B8860B',
+  darkgray = '#A9A9A9',
+  darkgreen = '#006400',
+  darkgrey = '#A9A9A9',
+  darkkhaki = '#BDB76B',
+  darkmagenta = '#8B008B',
+  darkolivegreen = '#556B2F',
+  darkorange = '#FF8C00',
+  darkorchid = '#9932CC',
+  darkred = '#8B0000',
+  darksalmon = '#E9967A',
+  darkseagreen = '#8FBC8F',
+  darkslateblue = '#483D8B',
+  darkslategray = '#2F4F4F',
+  darkslategrey = '#2F4F4F',
+  darkturquoise = '#00CED1',
+  darkviolet = '#9400D3',
+  deeppink = '#FF1493',
+  deepskyblue = '#00BFFF',
+  dimgray = '#696969',
+  dimgrey = '#696969',
+  dodgerblue = '#1E90FF',
+  firebrick = '#B22222',
+  floralwhite = '#FFFAF0',
+  forestgreen = '#228B22',
+  fuchsia = '#FF00FF',
+  gainsboro = '#DCDCDC',
+  ghostwhite = '#F8F8FF',
+  gold = '#FFD700',
+  goldenrod = '#DAA520',
+  gray = '#808080',
+  green = '#008000',
+  greenyellow = '#ADFF2F',
+  grey = '#808080',
+  honeydew = '#F0FFF0',
+  hotpink = '#FF69B4',
+  indianred = '#CD5C5C',
+  indigo = '#4B0082',
+  ivory = '#FFFFF0',
+  khaki = '#F0E68C',
+  lavender = '#E6E6FA',
+  lavenderblush = '#FFF0F5',
+  lawngreen = '#7CFC00',
+  lemonchiffon = '#FFFACD',
+  lightblue = '#ADD8E6',
+  lightcoral = '#F08080',
+  lightcyan = '#E0FFFF',
+  lightgoldenrodyellow = '#FAFAD2',
+  lightgray = '#D3D3D3',
+  lightgreen = '#90EE90',
+  lightgrey = '#D3D3D3',
+  lightpink = '#FFB6C1',
+  lightsalmon = '#FFA07A',
+  lightseagreen = '#20B2AA',
+  lightskyblue = '#87CEFA',
+  lightslategray = '#778899',
+  lightslategrey = '#778899',
+  lightsteelblue = '#B0C4DE',
+  lightyellow = '#FFFFE0',
+  lime = '#00FF00',
+  limegreen = '#32CD32',
+  linen = '#FAF0E6',
+  magenta = '#FF00FF',
+  maroon = '#800000',
+  mediumaquamarine = '#66CDAA',
+  mediumblue = '#0000CD',
+  mediumorchid = '#BA55D3',
+  mediumpurple = '#9370DB',
+  mediumseagreen = '#3CB371',
+  mediumslateblue = '#7B68EE',
+  mediumspringgreen = '#00FA9A',
+  mediumturquoise = '#48D1CC',
+  mediumvioletred = '#C71585',
+  midnightblue = '#191970',
+  mintcream = '#F5FFFA',
+  mistyrose = '#FFE4E1',
+  moccasin = '#FFE4B5',
+  navajowhite = '#FFDEAD',
+  navy = '#000080',
+  oldlace = '#FDF5E6',
+  olive = '#808000',
+  olivedrab = '#6B8E23',
+  orange = '#FFA500',
+  orangered = '#FF4500',
+  orchid = '#DA70D6',
+  palegoldenrod = '#EEE8AA',
+  palegreen = '#98FB98',
+  paleturquoise = '#AFEEEE',
+  palevioletred = '#DB7093',
+  papayawhip = '#FFEFD5',
+  peachpuff = '#FFDAB9',
+  peru = '#CD853F',
+  pink = '#FFC0CB',
+  plum = '#DDA0DD',
+  powderblue = '#B0E0E6',
+  purple = '#800080',
+  rebeccapurple = '#663399',
+  red = '#FF0000',
+  rosybrown = '#BC8F8F',
+  royalblue = '#4169E1',
+  saddlebrown = '#8B4513',
+  salmon = '#FA8072',
+  sandybrown = '#F4A460',
+  seagreen = '#2E8B57',
+  seashell = '#FFF5EE',
+  sienna = '#A0522D',
+  silver = '#C0C0C0',
+  skyblue = '#87CEEB',
+  slateblue = '#6A5ACD',
+  slategray = '#708090',
+  slategrey = '#708090',
+  snow = '#FFFAFA',
+  springgreen = '#00FF7F',
+  steelblue = '#4682B4',
+  tan = '#D2B48C',
+  teal = '#008080',
+  thistle = '#D8BFD8',
+  tomato = '#FF6347',
+  turquoise = '#40E0D0',
+  violet = '#EE82EE',
+  wheat = '#F5DEB3',
+  white = '#FFFFFF',
+  whitesmoke = '#F5F5F5',
+  yellow = '#FFFF00',
+  yellowgreen = '#9ACD32'
+}
+
+--- Check if a value is a CSS named colour.
+--- Performs case-insensitive matching against the 148 standard CSS named colours.
+--- @param value string|nil The colour value to check
+--- @return boolean True if the value is a recognised CSS named colour
+--- @usage local result = M.is_named_colour('rebeccapurple') -- returns true
+function M.is_named_colour(value)
+  if not value then return false end
+  return CSS_NAMED_COLOURS[value:lower()] ~= nil
+end
+
+-- ============================================================================
+-- COLOUR CONVERSION UTILITIES
+-- ============================================================================
+
+--- Expand 3-character hex colour to 6-character format.
+--- @param hex string Hex colour code (either #123 or #123456 format)
+--- @return string 6-character hex colour code (e.g., #123 becomes #112233)
+function M.expand_hex_colour(hex)
+  if string.len(hex) == 4 then
+    return (string.gsub(hex, '#(%x)(%x)(%x)', '#%1%1%2%2%3%3'))
+  end
+  return hex
+end
+
+--- Convert RGB colour notation to HTML hex format.
+--- @param rgb string RGB colour string in format "rgb(r, g, b)"
+--- @return string HTML hex colour code in uppercase format (e.g., "#FF0000")
+function M.RGB_to_HTML(rgb)
+  local r, g, b = rgb:match('rgb%((%d+)%s*,%s*(%d+)%s*,%s*(%d+)%s*%)')
+  r = tonumber(r)
+  g = tonumber(g)
+  b = tonumber(b)
+  return string.upper(string.format('#%02x%02x%02x', r, g, b))
+end
+
+--- Convert RGB percentage notation to HTML hex format.
+--- @param rgb string RGB colour string in format "rgb(r%, g%, b%)"
+--- @return string HTML hex colour code in uppercase format (e.g., "#FF0000")
+function M.RGBPercent_to_HTML(rgb)
+  local r, g, b = rgb:match('rgb%((%d+)%s*%%%s*,%s*(%d+)%s*%%%s*,%s*(%d+)%s*%%%s*%)')
+  r = math.floor(tonumber(r) * 255 / 100 + 0.5)
+  g = math.floor(tonumber(g) * 255 / 100 + 0.5)
+  b = math.floor(tonumber(b) * 255 / 100 + 0.5)
+  return string.upper(string.format('#%02x%02x%02x', r, g, b))
+end
+
+--- Helper function to convert hue to RGB component.
+--- @param p number
+--- @param q number
+--- @param t number
+--- @return number RGB component value
+function M.hue_to_rgb(p, q, t)
+  if t < 0 then t = t + 1 end
+  if t > 1 then t = t - 1 end
+  if t < 1 / 6 then return p + (q - p) * 6 * t end
+  if t < 1 / 2 then return q end
+  if t < 2 / 3 then return p + (q - p) * (2 / 3 - t) * 6 end
+  return p
+end
+
+--- Convert HSL colour notation to HTML hex format.
+--- @param hsl string HSL colour string in format "hsl(h, s%, l%)"
+--- @return string HTML hex colour code in uppercase format (e.g., "#FF0000")
+function M.HSL_to_HTML(hsl)
+  local h, s, l = hsl:match('hsl%((%d+)%s*,%s*(%d+)%%%s*,%s*(%d+)%%%s*%)')
+  h = tonumber(h) / 360
+  s = tonumber(s) / 100
+  l = tonumber(l) / 100
+
+  local r, g, b
+  if s == 0 then
+    r, g, b = l, l, l
+  else
+    local q = l < 0.5 and l * (1 + s) or l + s - l * s
+    local p = 2 * l - q
+    r = M.hue_to_rgb(p, q, h + 1 / 3)
+    g = M.hue_to_rgb(p, q, h)
+    b = M.hue_to_rgb(p, q, h - 1 / 3)
+  end
+
+  r = math.floor(r * 255 + 0.5)
+  g = math.floor(g * 255 + 0.5)
+  b = math.floor(b * 255 + 0.5)
+
+  return string.upper(string.format('#%02x%02x%02x', r, g, b))
+end
+
+--- Convert HWB colour notation to HTML hex format.
+--- @param hwb string HWB colour string in format "hwb(h w% b%)"
+--- @return string HTML hex colour code in uppercase format (e.g., "#FF0000")
+function M.HWB_to_HTML(hwb)
+  local h, w, b = hwb:match('hwb%((%d+)%s+(%d+)%%%s+(%d+)%%%s*%)')
+  h = tonumber(h)
+  w = tonumber(w) / 100
+  b = tonumber(b) / 100
+
+  local sum = w + b
+  if sum > 1 then
+    w = w / sum
+    b = b / sum
+  end
+
+  h = h / 360
+
+  local r, g, b_colour
+  local q = 1
+  local p = 0
+  r = M.hue_to_rgb(p, q, h + 1 / 3)
+  g = M.hue_to_rgb(p, q, h)
+  b_colour = M.hue_to_rgb(p, q, h - 1 / 3)
+
+  r = r * (1 - w - b) + w
+  g = g * (1 - w - b) + w
+  b_colour = b_colour * (1 - w - b) + w
+
+  r = math.floor(r * 255 + 0.5)
+  g = math.floor(g * 255 + 0.5)
+  b_colour = math.floor(b_colour * 255 + 0.5)
+
+  return string.upper(string.format('#%02x%02x%02x', r, g, b_colour))
+end
+
+--- Convert a CSS named colour to HTML hex format.
+--- @param name string CSS colour name (case-insensitive)
+--- @return string HTML hex colour code in uppercase format (e.g., "#FF0000")
+function M.named_to_HTML(name)
+  local hex = CSS_NAMED_COLOURS[name:lower()]
+  if not hex then
+    error('Unknown CSS named colour: ' .. tostring(name))
+  end
+  return hex
+end
+
+--- Convert a colour code to HTML format based on its format type.
+--- @param code string The colour code to convert
+--- @param format string The colour format (e.g., "hwb", "hsl", "rgb", "rgb_percent", "hex", "named")
+--- @return string HTML hex colour code
+function M.to_html(code, format)
+  local converters = {
+    hwb = M.HWB_to_HTML,
+    hsl = M.HSL_to_HTML,
+    rgb = M.RGB_to_HTML,
+    rgb_percent = M.RGBPercent_to_HTML,
+    hex = M.expand_hex_colour,
+    hex3 = M.expand_hex_colour,
+    hex6 = M.expand_hex_colour,
+    named = M.named_to_HTML
+  }
+
+  local converter = converters[format]
+  if converter then
+    return converter(code)
+  else
+    error('Unsupported colour format: ' .. format)
+  end
+end
+
+-- ============================================================================
+-- COLOUR ATTRIBUTE UTILITIES
+-- ============================================================================
+
+--- Get colour value from attributes table, accepting both British and American spellings.
+--- Checks for 'colour' first (British, primary), then falls back to 'color' (American).
+--- @param attrs table Attributes table (kwargs or element.attributes)
+--- @param default string|nil Default value if neither spelling is found
+--- @return string|nil Colour value or default
+--- @usage local colour = M.get_colour(kwargs, 'info')
+function M.get_colour(attrs, default)
+  if attrs == nil then
+    return default
+  end
+  local value = attrs.colour or attrs.color
+  if value == nil then
+    return default
+  end
+  local str_value = pandoc.utils.stringify(value)
+  if str_value == '' then
+    return default
+  end
+  return str_value
+end
+
+--- Check if a colour value is a custom colour (hex, rgb, hsl, hwb, etc.).
+--- Used to determine whether to apply a semantic class or inline style.
+--- Named CSS colours are not custom colours; they are standard/semantic values.
+--- @param colour string|nil The colour value to check
+--- @return boolean True if it's a custom colour value
+--- @usage local is_custom = M.is_custom_colour('#ff6600') -- returns true
+--- @usage local is_custom = M.is_custom_colour('red') -- returns false
+function M.is_custom_colour(colour)
+  if not colour then return false end
+  if M.is_named_colour(colour) then return false end
+  local lower = colour:lower()
+  return lower:match('^#') or lower:match('^rgb') or lower:match('^hsl') or lower:match('^hwb')
+end
+
+-- ============================================================================
+-- MODULE EXPORT
+-- ============================================================================
+
+return M

--- a/_extensions/gitlink/_schema.yml
+++ b/_extensions/gitlink/_schema.yml
@@ -62,3 +62,20 @@ options:
       extensions:
         - .yml
         - .yaml
+  enabled:
+    type: boolean
+    default: true
+    description: "Whether the filter is enabled for this document. Set to false in drafts or templates to opt out of link rewriting."
+  normalize-links:
+    type: boolean
+    default: true
+    description: "Whether to shorten platform URLs used as autolink text (e.g. <https://github.com/owner/repo/issues/1> becomes #1)."
+  fetch-titles:
+    type: boolean
+    default: false
+    description: "Whether to fetch the page title for autolinked platform URLs and use it as the link text. Requires network access via curl."
+  mentions:
+    type: array
+    description: "List of citation IDs to force-treat as Git hosting mentions even when a bibliography reference with the same id exists."
+    arrayOf:
+      type: string

--- a/_extensions/gitlink/_schema.yml
+++ b/_extensions/gitlink/_schema.yml
@@ -1,4 +1,4 @@
-# _schema.yml for "gitlink" filter extension
+# Schema for the gitlink extension
 # Describes options for IDE tooling and runtime validation.
 
 # Extension-level metadata options.
@@ -8,9 +8,13 @@
 #       platform: "github"
 #       repository-name: "owner/repo"
 
-$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v2/extension-schema.json
 
 options:
+  enabled:
+    type: boolean
+    default: true
+    description: "Whether the filter is enabled for the document, set to false in drafts or templates to opt out of link rewriting."
   platform:
     type: string
     default: "github"
@@ -21,13 +25,21 @@ options:
       - codeberg
       - gitea
       - bitbucket
-    enum-case-insensitive: true
+    enumCaseInsensitive: true
   repository-name:
     type: string
-    description: "Repository in 'owner/repo' format. Auto-detected from git remote if not set."
+    description: "Repository in 'owner/repo' format, auto-detected from the git remote when not set."
   base-url:
     type: string
-    description: "Base URL for the Git hosting platform. Defaults to the platform's standard URL."
+    description: "Base URL for the Git hosting platform, defaulting to the platform's standard URL."
+  custom-platforms-file:
+    type: string
+    description: "Path to a YAML file defining custom platform configurations."
+    completion:
+      type: file
+      extensions:
+        - .yml
+        - .yaml
   show-platform-badge:
     type: boolean
     default: true
@@ -42,40 +54,28 @@ options:
   badge-background-colour:
     type: string
     default: "#c3c3c3"
-    description: "Background colour for the platform badge."
+    description: "Background colour for the platform badge as a hex code or CSS named colour."
     aliases:
       - badge-background-color
     completion:
       type: color
   badge-text-colour:
     type: string
-    description: "Text colour for the platform badge."
+    description: "Text colour for the platform badge as a hex code or CSS named colour."
     aliases:
       - badge-text-color
     completion:
       type: color
-  custom-platforms-file:
-    type: string
-    description: "Path to a YAML file defining custom platform configurations."
-    completion:
-      type: file
-      extensions:
-        - .yml
-        - .yaml
-  enabled:
-    type: boolean
-    default: true
-    description: "Whether the filter is enabled for this document. Set to false in drafts or templates to opt out of link rewriting."
   normalize-links:
     type: boolean
     default: true
-    description: "Whether to shorten platform URLs used as autolink text (e.g. <https://github.com/owner/repo/issues/1> becomes #1)."
+    description: "Whether to shorten platform URLs used as autolink text, so <https://github.com/owner/repo/issues/1> becomes #1."
   fetch-titles:
     type: boolean
     default: false
-    description: "Whether to fetch the page title for autolinked platform URLs and use it as the link text. Requires network access via curl."
+    description: "Whether to fetch the page title for autolinked platform URLs and use it as the link text, requiring network access via curl."
   mentions:
     type: array
     description: "List of citation IDs to force-treat as Git hosting mentions even when a bibliography reference with the same id exists."
-    arrayOf:
+    items:
       type: string

--- a/_extensions/gitlink/gitlink.lua
+++ b/_extensions/gitlink/gitlink.lua
@@ -15,6 +15,7 @@ local paths = require(quarto.utils.resolve_path('_modules/paths.lua'):gsub('%.lu
 local git = require(quarto.utils.resolve_path('_modules/git.lua'):gsub('%.lua$', ''))
 local bitbucket = require(quarto.utils.resolve_path('_modules/bitbucket.lua'):gsub('%.lua$', ''))
 local platforms = require(quarto.utils.resolve_path('_modules/platforms.lua'):gsub('%.lua$', ''))
+local colour = require(quarto.utils.resolve_path('_modules/colour.lua'):gsub('%.lua$', ''))
 
 --- @type string The platform type (github, gitlab, codeberg, gitea, bitbucket)
 local platform = 'github'
@@ -28,6 +29,12 @@ local base_url = 'https://github.com'
 --- @type table<string, boolean> Set of reference IDs from the document
 local references_ids_set = {}
 
+--- @type table<string, boolean> Set of citation IDs forced to be treated as mentions
+local force_mentions_set = {}
+
+--- @type boolean Whether the filter is enabled for this document
+local is_enabled = true
+
 --- @type boolean Whether to show visible platform badges
 local show_platform_badge = true
 
@@ -37,8 +44,23 @@ local badge_position = 'after'
 --- @type string Badge background colour (hex or colour name)
 local badge_background_colour = '#c3c3c3'
 
---- @type string Badge text colour (hex or colour name)
+--- @type string|nil Badge text colour (hex or colour name)
 local badge_text_colour = nil
+
+--- @type boolean Whether to shorten link text matching platform URLs
+local normalize_links = true
+
+--- @type boolean Whether to fetch issue/PR/commit titles for link text
+local fetch_titles = false
+
+--- @type table<string, string> Cache of fetched titles by URL
+local title_cache = {}
+
+--- @type table<string, table>|nil Cached platform configurations by name (per render)
+local platform_config_cache = nil
+
+--- @type table<integer, string>|nil Cached list of all known platform names (per render)
+local all_platform_names_cache = nil
 
 --- @type integer Full length of a git commit SHA
 local COMMIT_SHA_FULL_LENGTH = 40
@@ -49,11 +71,89 @@ local COMMIT_SHA_SHORT_LENGTH = 7
 --- @type integer Minimum length for a valid git commit SHA
 local COMMIT_SHA_MIN_LENGTH = 7
 
---- Get platform configuration
+--- @type string Lua pattern matching a 3-, 4-, 6-, or 8-character hex colour with leading #
+local HEX_COLOUR_PATTERN = '^#%x%x%x%x?%x?%x?%x?%x?$'
+
+--- Validate a colour value as a hex code or CSS named colour.
+--- Returns the original value if valid, or nil if invalid.
+--- @param value string|nil The candidate colour value
+--- @param option_label string The metadata option name (for warnings)
+--- @return string|nil The validated colour value, or nil if invalid
+local function validate_colour(value, option_label)
+  if str.is_empty(value) then
+    return nil
+  end
+  local s = value --[[@as string]]
+  if s:match(HEX_COLOUR_PATTERN) then
+    return s
+  end
+  if colour.is_named_colour(s) then
+    return s
+  end
+  log.log_warning(
+    EXTENSION_NAME,
+    "Ignoring invalid '" .. option_label .. "' value '" .. s ..
+    "': expected a hex colour (e.g. '#c3c3c3') or a CSS named colour."
+  )
+  return nil
+end
+
+--- Reset all module-level state to defaults.
+--- Quarto can render multiple documents in one process, so module-level state
+--- from a previous document must be cleared at the start of each Meta pass.
+local function reset_state()
+  platform = 'github'
+  repository_name = nil
+  base_url = 'https://github.com'
+  references_ids_set = {}
+  force_mentions_set = {}
+  is_enabled = true
+  show_platform_badge = true
+  badge_position = 'after'
+  badge_background_colour = '#c3c3c3'
+  badge_text_colour = nil
+  normalize_links = true
+  fetch_titles = false
+  title_cache = {}
+  platform_config_cache = nil
+  all_platform_names_cache = nil
+  if platforms.clear_custom_platforms then
+    platforms.clear_custom_platforms()
+  end
+end
+
+--- Get the cached list of all known platform names.
+--- @return table<integer, string> List of platform names
+local function get_all_platform_names()
+  if not all_platform_names_cache then
+    all_platform_names_cache = platforms.get_all_platform_names()
+  end
+  return all_platform_names_cache
+end
+
+--- Get platform configuration (cached per render).
+--- Memoises lookups against `platform_config_cache` to avoid repeated calls
+--- to the platforms module for every Str element in the document.
 --- @param platform_name string The platform name
 --- @return table|nil The platform configuration or nil if not found
 local function get_platform_config(platform_name)
-  return platforms.get_platform_config(platform_name:lower())
+  if not platform_name then
+    return nil
+  end
+  local key = platform_name:lower()
+  if not platform_config_cache then
+    platform_config_cache = {}
+  end
+  local cached = platform_config_cache[key]
+  if cached ~= nil then
+    if cached == false then
+      return nil
+    end
+    return cached
+  end
+  local config = platforms.get_platform_config(key)
+  platform_config_cache[key] = config or false
+  return config
 end
 
 --- Parse a full repository URL to extract platform, base-url, and owner/repo.
@@ -63,9 +163,9 @@ end
 --- @return string|nil matched_base_url The base URL portion
 --- @return string|nil repo_path The owner/repo portion
 local function parse_repo_url(url)
-  local all_names = platforms.get_all_platform_names()
+  local all_names = get_all_platform_names()
   for _, name in ipairs(all_names) do
-    local config = platforms.get_platform_config(name)
+    local config = get_platform_config(name)
     if config and config.base_url then
       local escaped = str.escape_pattern(config.base_url)
       local repo_path = url:match('^' .. escaped .. '/(.+)$')
@@ -143,13 +243,22 @@ local function create_platform_link(text, uri, platform_name)
     local link = pandoc.Link(link_content, uri --[[@as string]], '', link_attr)
 
     if show_platform_badge then
-      local bg_colour = badge_background_colour
+      -- Typst rgb() only accepts hex strings, so convert any CSS-named colour
+      -- (already validated at Meta time) to its hex equivalent.
+      local bg_hex = badge_background_colour
+      if bg_hex and not bg_hex:match(HEX_COLOUR_PATTERN) and colour.is_named_colour(bg_hex) then
+        bg_hex = colour.named_to_HTML(bg_hex)
+      end
       local text_colour_opt = ''
       if not str.is_empty(badge_text_colour) then
-        text_colour_opt = ', fill: rgb("' .. badge_text_colour .. '")'
+        local text_hex = badge_text_colour --[[@as string]]
+        if not text_hex:match(HEX_COLOUR_PATTERN) and colour.is_named_colour(text_hex) then
+          text_hex = colour.named_to_HTML(text_hex)
+        end
+        text_colour_opt = ', fill: rgb("' .. text_hex .. '")'
       end
       local badge_raw = '#box(fill: rgb("' ..
-          bg_colour ..
+          bg_hex ..
           '"), inset: 2pt, outset: 0pt, radius: 3pt, baseline: -0.3em, text(size: 0.45em' ..
           text_colour_opt .. ', [' .. platform_label .. ']))'
       local badge = pandoc.RawInline('typst', ' ' .. badge_raw)
@@ -178,6 +287,25 @@ end
 --- @param meta table The document metadata table.
 --- @return table The metadata table (unchanged).
 local function get_repository(meta)
+  -- Reset module-level state at the start of every document so a previous
+  -- render in a batch does not bleed into this one.
+  reset_state()
+
+  -- Allow opt-out at the document level for drafts, templates, or any
+  -- document where automatic link rewriting is undesirable. Read directly
+  -- from metadata because get_metadata_value() returns nil for boolean
+  -- false (the truthy guard inside it treats false as missing).
+  local extensions_meta = meta and meta['extensions']
+  local gitlink_meta = extensions_meta and extensions_meta['gitlink']
+  local enabled_meta = gitlink_meta and gitlink_meta['enabled']
+  if enabled_meta ~= nil then
+    local enabled_lower = str.stringify(enabled_meta):lower()
+    is_enabled = enabled_lower ~= 'false'
+  end
+  if not is_enabled then
+    return meta
+  end
+
   local meta_platform = meta_mod.get_metadata_value(meta, 'gitlink', 'platform')
   local meta_base_url = meta_mod.get_metadata_value(meta, 'gitlink', 'base-url')
   local meta_repository = meta_mod.get_metadata_value(meta, 'gitlink', 'repository-name')
@@ -227,7 +355,7 @@ local function get_repository(meta)
 
   local config = get_platform_config(platform)
   if not config then
-    local available_platforms = table.concat(platforms.get_all_platform_names(), ', ')
+    local available_platforms = table.concat(get_all_platform_names(), ', ')
     log.log_error(
       EXTENSION_NAME,
       "Unsupported platform: '" .. platform ..
@@ -254,9 +382,12 @@ local function get_repository(meta)
     repository_name = git.get_repository()
   end
 
-  local show_badge_meta = meta_mod.get_metadata_value(meta, 'gitlink', 'show-platform-badge')
+  -- Read directly because get_metadata_value() returns nil for boolean
+  -- false (the truthy guard inside it treats false as missing).
+  local show_badge_meta = gitlink_meta and gitlink_meta['show-platform-badge']
   if show_badge_meta ~= nil then
-    show_platform_badge = (show_badge_meta == "true" or show_badge_meta == true)
+    local show_badge_str = str.stringify(show_badge_meta):lower()
+    show_platform_badge = (show_badge_str ~= 'false')
   end
 
   local badge_pos_meta = meta_mod.get_metadata_value(meta, 'gitlink', 'badge-position')
@@ -266,12 +397,49 @@ local function get_repository(meta)
 
   local badge_bg_colour_meta = meta_mod.get_metadata_value(meta, 'gitlink', 'badge-background-colour')
   if not str.is_empty(badge_bg_colour_meta) then
-    badge_background_colour = badge_bg_colour_meta --[[@as string]]
+    local validated_bg = validate_colour(badge_bg_colour_meta --[[@as string]], 'badge-background-colour')
+    if validated_bg then
+      badge_background_colour = validated_bg
+    end
   end
 
   local badge_text_colour_meta = meta_mod.get_metadata_value(meta, 'gitlink', 'badge-text-colour')
   if not str.is_empty(badge_text_colour_meta) then
-    badge_text_colour = badge_text_colour_meta --[[@as string]]
+    local validated_text = validate_colour(badge_text_colour_meta --[[@as string]], 'badge-text-colour')
+    if validated_text then
+      badge_text_colour = validated_text
+    end
+  end
+
+  -- Read directly because get_metadata_value() returns nil for boolean
+  -- false (the truthy guard inside it treats false as missing).
+  local normalize_links_meta = gitlink_meta and gitlink_meta['normalize-links']
+  if normalize_links_meta ~= nil then
+    normalize_links = (str.stringify(normalize_links_meta):lower() ~= 'false')
+  end
+
+  local fetch_titles_meta = gitlink_meta and gitlink_meta['fetch-titles']
+  if fetch_titles_meta ~= nil then
+    fetch_titles = (str.stringify(fetch_titles_meta):lower() == 'true')
+  end
+
+  -- Read the optional `mentions` list (citation IDs to force-treat as mentions).
+  -- Direct table access because get_metadata_value flattens lists via stringify.
+  local mentions_meta = gitlink_meta and gitlink_meta['mentions']
+  if mentions_meta then
+    if type(mentions_meta) == 'table' then
+      for _, mention in ipairs(mentions_meta) do
+        local id = str.stringify(mention)
+        if not str.is_empty(id) then
+          force_mentions_set[id] = true
+        end
+      end
+    else
+      local id = str.stringify(mentions_meta)
+      if not str.is_empty(id) then
+        force_mentions_set[id] = true
+      end
+    end
   end
 
   return meta
@@ -292,27 +460,33 @@ local function get_references(doc)
   return doc
 end
 
---- Process Git hosting mentions in citations
---- Distinguishes between actual bibliography citations and Git hosting @mentions
+--- Process Git hosting mentions in citations.
+--- Distinguishes between actual bibliography citations and Git hosting @mentions.
+--- When the citation id appears in `gitlink.mentions`, the citation is forced
+--- to be treated as a mention even if a reference with that id exists.
 --- @param cite pandoc.Cite The citation element
 --- @return pandoc.Cite|pandoc.Link The original citation or a Git hosting mention link
 local function process_mentions(cite)
-  if references_ids_set[cite.citations[1].id] then
-    return cite
-  else
-    local mention_text = str.stringify(cite.content)
-    local config = get_platform_config(platform)
-    if config and config.patterns.user then
-      local username = mention_text:match(config.patterns.user)
-      if username then
-        local url_format = config.url_formats.user
-        local uri = base_url .. url_format:gsub("{username}", username)
-        local link = create_platform_link(mention_text, uri, platform)
-        return link or cite
-      end
-    end
+  if not is_enabled then
     return cite
   end
+  local cite_id = cite.citations[1] and cite.citations[1].id or nil
+  local force_mention = cite_id and force_mentions_set[cite_id] or false
+  if not force_mention and cite_id and references_ids_set[cite_id] then
+    return cite
+  end
+  local mention_text = str.stringify(cite.content)
+  local config = get_platform_config(platform)
+  if config and config.patterns.user then
+    local username = mention_text:match(config.patterns.user)
+    if username then
+      local url_format = config.url_formats.user
+      local uri = base_url .. url_format:gsub("{username}", username)
+      local link = create_platform_link(mention_text, uri, platform)
+      return link or cite
+    end
+  end
+  return cite
 end
 
 
@@ -376,9 +550,9 @@ local function process_issues_and_mrs(elem, current_platform, current_base_url)
   end
 
   if not number then
-    local all_platform_names = platforms.get_all_platform_names()
+    local all_platform_names = get_all_platform_names()
     for _, platform_name in ipairs(all_platform_names) do
-      local platform_config = platforms.get_platform_config(platform_name)
+      local platform_config = get_platform_config(platform_name)
       if platform_config then
         local platform_base_url = platform_config.base_url
         local escaped_platform_url = str.escape_pattern(platform_base_url)
@@ -474,9 +648,9 @@ local function process_users(elem, current_platform)
   local text = elem.text
   local username = nil
 
-  local all_platform_names = platforms.get_all_platform_names()
+  local all_platform_names = get_all_platform_names()
   for _, platform_name in ipairs(all_platform_names) do
-    local platform_config = platforms.get_platform_config(platform_name)
+    local platform_config = get_platform_config(platform_name)
     if platform_config then
       local platform_base_url = platform_config.base_url
       local escaped_platform_url = str.escape_pattern(platform_base_url)
@@ -523,9 +697,13 @@ local function process_commits(elem, current_platform, current_base_url)
       short_link = commit_sha:sub(1, COMMIT_SHA_SHORT_LENGTH)
       break
     elseif pattern == "([^/]+/[^/@]+)@(%x+)" and text:match("^([^/]+/[^/@]+)@(%x+)$") then
-      repo, commit_sha = text:match("^([^/]+/[^/@]+)@(%x+)$")
-      short_link = repo .. "@" .. commit_sha:sub(1, COMMIT_SHA_SHORT_LENGTH)
-      break
+      local r, sha = text:match("^([^/]+/[^/@]+)@(%x+)$")
+      if sha:len() >= COMMIT_SHA_MIN_LENGTH and sha:len() <= COMMIT_SHA_FULL_LENGTH then
+        repo = r
+        commit_sha = sha
+        short_link = repo .. "@" .. commit_sha:sub(1, COMMIT_SHA_SHORT_LENGTH)
+        break
+      end
     elseif pattern == "(%w+)@(%x+)" and text:match("^(%w+)@(%x+)$") then
       local user, sha = text:match("^(%w+)@(%x+)$")
       if repository_name and sha:len() >= COMMIT_SHA_MIN_LENGTH and sha:len() <= COMMIT_SHA_FULL_LENGTH then
@@ -541,16 +719,18 @@ local function process_commits(elem, current_platform, current_base_url)
   end
 
   if not commit_sha then
-    local all_platform_names = platforms.get_all_platform_names()
+    local all_platform_names = get_all_platform_names()
     for _, platform_name in ipairs(all_platform_names) do
-      local platform_config = platforms.get_platform_config(platform_name)
+      local platform_config = get_platform_config(platform_name)
       if platform_config then
         local platform_base_url = platform_config.base_url
         local escaped_platform_url = str.escape_pattern(platform_base_url)
-        local url_pattern = '^' .. escaped_platform_url .. '/([^/]+/[^/]+)/%-?/?commits?/(%x+)'
+        local url_pattern = '^' .. escaped_platform_url .. '/([^/]+/[^/]+)/%-?/?commits?/(%x+)$'
         if text:match(url_pattern) then
-          repo, commit_sha = text:match(url_pattern)
-          if commit_sha:len() >= COMMIT_SHA_MIN_LENGTH then
+          local r, sha = text:match(url_pattern)
+          if sha:len() >= COMMIT_SHA_MIN_LENGTH and sha:len() <= COMMIT_SHA_FULL_LENGTH then
+            repo = r
+            commit_sha = sha
             if repo == repository_name then
               short_link = commit_sha:sub(1, COMMIT_SHA_SHORT_LENGTH)
             else
@@ -566,7 +746,9 @@ local function process_commits(elem, current_platform, current_base_url)
     end
   end
 
-  if commit_sha and repo and commit_sha:len() >= COMMIT_SHA_MIN_LENGTH then
+  if commit_sha and repo
+      and commit_sha:len() >= COMMIT_SHA_MIN_LENGTH
+      and commit_sha:len() <= COMMIT_SHA_FULL_LENGTH then
     local url_format = config.url_formats.commit
     local uri = matched_base_url .. url_format:gsub("{repo}", repo):gsub("{sha}", commit_sha)
     return create_platform_link(short_link, uri, matched_platform), matched_platform, matched_base_url
@@ -580,8 +762,20 @@ end
 --- @param elem pandoc.Str The string element to process
 --- @return pandoc.Str|pandoc.Link|pandoc.List The original element, a link, or a list of inlines
 local function process_gitlink(elem)
+  if not is_enabled then
+    return elem
+  end
   if not platform or not base_url or str.is_empty(platform) then
     return elem
+  end
+  -- When link normalisation is disabled, leave bare URL tokens alone.
+  -- Pandoc represents the visible text of an autolink as a Str inside the
+  -- Link element, so skipping URL-shaped tokens preserves the URL text.
+  if not normalize_links then
+    local t = elem.text
+    if t and (t:sub(1, 7) == 'http://' or t:sub(1, 8) == 'https://') then
+      return elem
+    end
   end
 
   -- Fast path: try matching the raw text directly
@@ -654,20 +848,90 @@ end
 --- @param elem table Block element containing inline content
 --- @return table The modified element
 local function process_inlines(elem)
+  if not is_enabled then
+    return elem
+  end
   if elem.content and platform == "bitbucket" then
     elem.content = bitbucket.process_inlines(elem.content, base_url, repository_name, create_platform_link)
   end
   return elem
 end
 
---- Process Link elements to shorten URLs that are used as link text
+--- Fetch the HTML <title> of a URL via curl (best-effort, cached per render).
+--- Returns nil when fetching is disabled, the URL cannot be reached, or curl
+--- is not available. Failures log a warning but never abort the render.
+--- @param uri string The URL to fetch
+--- @return string|nil The page title, or nil if unavailable
+local function fetch_title_for(uri)
+  if not fetch_titles then
+    return nil
+  end
+  if title_cache[uri] ~= nil then
+    local cached = title_cache[uri]
+    if cached == false then
+      return nil
+    end
+    return cached
+  end
+  if uri:find('"', 1, true) or uri:find("'", 1, true) then
+    title_cache[uri] = false
+    return nil
+  end
+  local handle = io.popen(
+    'curl -fsSL --max-time 5 -A "quarto-gitlink" "' .. uri .. '" 2>/dev/null', 'r'
+  )
+  if not handle then
+    log.log_warning(EXTENSION_NAME, "Title fetch unavailable (could not start curl).")
+    title_cache[uri] = false
+    return nil
+  end
+  local body = handle:read('*a') or ''
+  handle:close()
+  local raw_title = body:match('<title[^>]*>(.-)</title>')
+  if not raw_title or raw_title == '' then
+    title_cache[uri] = false
+    return nil
+  end
+  local decoded = raw_title
+      :gsub('&amp;', '&')
+      :gsub('&lt;', '<')
+      :gsub('&gt;', '>')
+      :gsub('&quot;', '"')
+      :gsub('&#39;', "'")
+  local trimmed = str.trim(decoded)
+  if trimmed == '' then
+    title_cache[uri] = false
+    return nil
+  end
+  title_cache[uri] = trimmed
+  return trimmed
+end
+
+--- Process Link elements to shorten platform URLs used as link text.
+--- When `gitlink.normalize-links` is true (the default), an autolink whose text
+--- equals its target (e.g. `<https://github.com/owner/repo/issues/1>`) is
+--- shortened to the platform-style form (e.g. `#1`).
+--- When `gitlink.fetch-titles` is true, an autolink whose target points at a
+--- known platform URL is given a title-derived link text (issue/PR/commit
+--- title) instead of the URL when the fetch succeeds.
 --- @param elem pandoc.Link The link element to process
 --- @return pandoc.Link The original or modified link
 local function process_link(elem)
+  if not is_enabled or not normalize_links then
+    return elem
+  end
+
   local link_text = str.stringify(elem.content)
   local link_target = elem.target
 
   if link_text == link_target then
+    if fetch_titles then
+      local title = fetch_title_for(link_target)
+      if title then
+        return pandoc.Link({ pandoc.Str(title) }, link_target, '', elem.attr)
+      end
+    end
+
     local temp_str = pandoc.Str(link_text)
     local result = process_gitlink(temp_str)
 

--- a/_extensions/gitlink/gitlink.lua
+++ b/_extensions/gitlink/gitlink.lua
@@ -56,8 +56,8 @@ local fetch_titles = false
 --- @type table<string, string> Cache of fetched titles by URL
 local title_cache = {}
 
---- @type table<string, table>|nil Cached platform configurations by name (per render)
-local platform_config_cache = nil
+--- @type table<string, table|false> Cached platform configurations by name (per render); false means "looked up and not found"
+local platform_config_cache = {}
 
 --- @type table<integer, string>|nil Cached list of all known platform names (per render)
 local all_platform_names_cache = nil
@@ -84,10 +84,7 @@ local function validate_colour(value, option_label)
     return nil
   end
   local s = value --[[@as string]]
-  if s:match(HEX_COLOUR_PATTERN) then
-    return s
-  end
-  if colour.is_named_colour(s) then
+  if s:match(HEX_COLOUR_PATTERN) or colour.is_named_colour(s) then
     return s
   end
   log.log_warning(
@@ -96,6 +93,34 @@ local function validate_colour(value, option_label)
     "': expected a hex colour (e.g. '#c3c3c3') or a CSS named colour."
   )
   return nil
+end
+
+--- Convert a validated colour value to its hex form for Typst rgb().
+--- Hex codes are returned unchanged; CSS named colours are resolved via
+--- the colour module. Assumes the value has already been validated.
+--- @param value string The colour value (hex code or CSS named colour)
+--- @return string The hex form
+local function colour_to_hex(value)
+  if value:match(HEX_COLOUR_PATTERN) then
+    return value
+  end
+  return colour.named_to_HTML(value)
+end
+
+--- Read a boolean metadata value with a default.
+--- `get_metadata_value()` returns nil for boolean `false` (its truthy guard
+--- treats false as missing), so this helper reads the raw value directly
+--- and coerces it via `tostring`.
+--- @param gitlink_meta table|nil The `extensions.gitlink` metadata sub-table
+--- @param key string The option key
+--- @param default boolean The default when the option is absent
+--- @return boolean The resolved boolean value
+local function read_boolean_meta(gitlink_meta, key, default)
+  local value = gitlink_meta and gitlink_meta[key]
+  if value == nil then
+    return default
+  end
+  return str.stringify(value):lower() ~= 'false'
 end
 
 --- Reset all module-level state to defaults.
@@ -115,7 +140,7 @@ local function reset_state()
   normalize_links = true
   fetch_titles = false
   title_cache = {}
-  platform_config_cache = nil
+  platform_config_cache = {}
   all_platform_names_cache = nil
   if platforms.clear_custom_platforms then
     platforms.clear_custom_platforms()
@@ -134,6 +159,8 @@ end
 --- Get platform configuration (cached per render).
 --- Memoises lookups against `platform_config_cache` to avoid repeated calls
 --- to the platforms module for every Str element in the document.
+--- The cache stores `false` for "looked up and not found" so repeated misses
+--- skip the underlying lookup.
 --- @param platform_name string The platform name
 --- @return table|nil The platform configuration or nil if not found
 local function get_platform_config(platform_name)
@@ -141,15 +168,9 @@ local function get_platform_config(platform_name)
     return nil
   end
   local key = platform_name:lower()
-  if not platform_config_cache then
-    platform_config_cache = {}
-  end
   local cached = platform_config_cache[key]
   if cached ~= nil then
-    if cached == false then
-      return nil
-    end
-    return cached
+    return cached or nil
   end
   local config = platforms.get_platform_config(key)
   platform_config_cache[key] = config or false
@@ -245,17 +266,10 @@ local function create_platform_link(text, uri, platform_name)
     if show_platform_badge then
       -- Typst rgb() only accepts hex strings, so convert any CSS-named colour
       -- (already validated at Meta time) to its hex equivalent.
-      local bg_hex = badge_background_colour
-      if bg_hex and not bg_hex:match(HEX_COLOUR_PATTERN) and colour.is_named_colour(bg_hex) then
-        bg_hex = colour.named_to_HTML(bg_hex)
-      end
+      local bg_hex = colour_to_hex(badge_background_colour)
       local text_colour_opt = ''
       if not str.is_empty(badge_text_colour) then
-        local text_hex = badge_text_colour --[[@as string]]
-        if not text_hex:match(HEX_COLOUR_PATTERN) and colour.is_named_colour(text_hex) then
-          text_hex = colour.named_to_HTML(text_hex)
-        end
-        text_colour_opt = ', fill: rgb("' .. text_hex .. '")'
+        text_colour_opt = ', fill: rgb("' .. colour_to_hex(badge_text_colour --[[@as string]]) .. '")'
       end
       local badge_raw = '#box(fill: rgb("' ..
           bg_hex ..
@@ -292,16 +306,10 @@ local function get_repository(meta)
   reset_state()
 
   -- Allow opt-out at the document level for drafts, templates, or any
-  -- document where automatic link rewriting is undesirable. Read directly
-  -- from metadata because get_metadata_value() returns nil for boolean
-  -- false (the truthy guard inside it treats false as missing).
+  -- document where automatic link rewriting is undesirable.
   local extensions_meta = meta and meta['extensions']
   local gitlink_meta = extensions_meta and extensions_meta['gitlink']
-  local enabled_meta = gitlink_meta and gitlink_meta['enabled']
-  if enabled_meta ~= nil then
-    local enabled_lower = str.stringify(enabled_meta):lower()
-    is_enabled = enabled_lower ~= 'false'
-  end
+  is_enabled = read_boolean_meta(gitlink_meta, 'enabled', true)
   if not is_enabled then
     return meta
   end
@@ -382,13 +390,7 @@ local function get_repository(meta)
     repository_name = git.get_repository()
   end
 
-  -- Read directly because get_metadata_value() returns nil for boolean
-  -- false (the truthy guard inside it treats false as missing).
-  local show_badge_meta = gitlink_meta and gitlink_meta['show-platform-badge']
-  if show_badge_meta ~= nil then
-    local show_badge_str = str.stringify(show_badge_meta):lower()
-    show_platform_badge = (show_badge_str ~= 'false')
-  end
+  show_platform_badge = read_boolean_meta(gitlink_meta, 'show-platform-badge', true)
 
   local badge_pos_meta = meta_mod.get_metadata_value(meta, 'gitlink', 'badge-position')
   if badge_pos_meta ~= nil then
@@ -411,13 +413,10 @@ local function get_repository(meta)
     end
   end
 
-  -- Read directly because get_metadata_value() returns nil for boolean
-  -- false (the truthy guard inside it treats false as missing).
-  local normalize_links_meta = gitlink_meta and gitlink_meta['normalize-links']
-  if normalize_links_meta ~= nil then
-    normalize_links = (str.stringify(normalize_links_meta):lower() ~= 'false')
-  end
+  normalize_links = read_boolean_meta(gitlink_meta, 'normalize-links', true)
 
+  -- Default-false flag: only literal 'true' enables it (matches YAML boolean
+  -- coercion). Anything else falls back to false.
   local fetch_titles_meta = gitlink_meta and gitlink_meta['fetch-titles']
   if fetch_titles_meta ~= nil then
     fetch_titles = (str.stringify(fetch_titles_meta):lower() == 'true')
@@ -470,9 +469,8 @@ local function process_mentions(cite)
   if not is_enabled then
     return cite
   end
-  local cite_id = cite.citations[1] and cite.citations[1].id or nil
-  local force_mention = cite_id and force_mentions_set[cite_id] or false
-  if not force_mention and cite_id and references_ids_set[cite_id] then
+  local cite_id = cite.citations[1] and cite.citations[1].id
+  if cite_id and not force_mentions_set[cite_id] and references_ids_set[cite_id] then
     return cite
   end
   local mention_text = str.stringify(cite.content)
@@ -866,12 +864,9 @@ local function fetch_title_for(uri)
   if not fetch_titles then
     return nil
   end
-  if title_cache[uri] ~= nil then
-    local cached = title_cache[uri]
-    if cached == false then
-      return nil
-    end
-    return cached
+  local cached = title_cache[uri]
+  if cached ~= nil then
+    return cached or nil
   end
   if uri:find('"', 1, true) or uri:find("'", 1, true) then
     title_cache[uri] = false

--- a/example.qmd
+++ b/example.qmd
@@ -25,7 +25,7 @@ A Quarto extension that automatically converts Git hosting platform references (
 ## Installation
 
 ```bash
-quarto add mcanouil/quarto-gitlink@1.5.2
+quarto add mcanouil/quarto-gitlink@1.6.0
 ```
 
 This will install the extension under the `_extensions` subdirectory.
@@ -424,7 +424,57 @@ extensions:
 
 These colours will be applied to badges in both HTML and Typst output formats.
 
-**Contributing New Platforms**:
+Invalid colour values (anything that is neither a hex code nor a recognised CSS named colour) are rejected with a warning and the default colour is used.
+
+## Disabling the Filter
+
+Set `gitlink.enabled: false` to opt a single document out of link rewriting, for example in drafts or templates:
+
+```yaml
+extensions:
+  gitlink:
+    enabled: false
+```
+
+With `enabled: false`, references such as `#1`, `@mcanouil`, and full URLs are left untouched.
+
+## URL Normalisation
+
+By default, autolinked platform URLs (`<https://github.com/owner/repo/issues/1>`) are shortened to the platform-style form (`#1`).
+Set `normalize-links: false` to leave them as-is:
+
+```yaml
+extensions:
+  gitlink:
+    normalize-links: false
+```
+
+## Title Fetching
+
+Set `fetch-titles: true` to replace the link text of an autolinked platform URL with the fetched page title (best-effort via `curl`):
+
+```yaml
+extensions:
+  gitlink:
+    fetch-titles: true
+```
+
+The fetch is best-effort: if the network is unavailable or the page does not return a `<title>`, the original behaviour (URL shortening or unchanged URL text) is used.
+
+## Forcing Mentions Over Citations
+
+When a Quarto bibliography contains an entry whose id matches a Git hosting username, Pandoc treats `@name` as a citation.
+To force-treat selected citation IDs as Git hosting mentions, list them under `mentions`:
+
+```yaml
+extensions:
+  gitlink:
+    mentions:
+      - mcanouil
+      - other-username
+```
+
+## Contributing New Platforms
 
 To contribute a new platform to the built-in configuration:
 

--- a/example.qmd
+++ b/example.qmd
@@ -25,7 +25,7 @@ A Quarto extension that automatically converts Git hosting platform references (
 ## Installation
 
 ```bash
-quarto add mcanouil/quarto-gitlink@1.6.0
+quarto add mcanouil/quarto-gitlink@1.5.2
 ```
 
 This will install the extension under the `_extensions` subdirectory.


### PR DESCRIPTION
Implements the v1.5.2 review brief for `quarto-gitlink`.
Adds colour validation, tightens commit-SHA length checks for cross-repository references, lets authors override the citation/mention split, resets module-level state between documents in batch renders, and introduces four new metadata options: `enabled`, `normalize-links`, `fetch-titles`, and `mentions`.

- fix: Validate `badge-background-colour` and `badge-text-colour` against hex codes and CSS named colours; invalid values now log `(W) [gitlink] Ignoring invalid '…' value '…'` and fall back to defaults instead of producing broken inline styles or invalid Typst `rgb()` calls.
- fix: Reject cross-repository commit references (`owner/repo@<sha>`) whose SHA is shorter than 7 or longer than 40 hexadecimal characters; previously over-length SHAs (for example, 48 hex chars) produced an incorrect commit link.
- fix: Reset module-level state at the start of every `Meta` pass so batch renders no longer leak platform, repository, badge, reference, or custom-platform state across documents.
- fix: Respect boolean `false` for `show-platform-badge`, `enabled`, and `normalize-links` (the previous metadata accessor returned `nil` for boolean false, silently keeping defaults).
- feat: Add `gitlink.enabled` boolean (default `true`) so drafts and templates can opt out of link rewriting in a single document.
- feat: Add `gitlink.normalize-links` boolean (default `true`) to toggle URL shortening of autolinked platform URLs.
- feat: Add `gitlink.fetch-titles` boolean (default `false`) to use the page title of an autolinked platform URL as the link text (best-effort via `curl`, cached per render).
- feat: Add `gitlink.mentions` list to force-treat specified citation IDs as Git hosting mentions even when a bibliography reference with the same id exists.
- refactor: Cache platform-config lookups per render so the platforms module is no longer queried on every `Str` element.
- refactor: Add canonical `colour.lua` shared module and use it for hex/named colour validation.
- docs: Update `README.md`, `example.qmd`, `CHANGELOG.md`, and `_schema.yml` to cover the new options and the v1.6.0 install instruction.
- chore: Bump `_extension.yml` from `1.5.2` to `1.6.0` (stable minor bump, behavioural fixes and additive options).
