### PR TITLE
fix: recognise comma-separated groups of references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- fix: Recognise groups of references separated by commas, both spaced (`(#2, #3)`, `(#1, #2, #3)`) and without spaces (`(#2,#3)`, `#2,#3`); a comma-separated group is linked only when every item is a valid reference.
+
 ## 1.6.0 (2026-05-31)
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -171,6 +171,13 @@ extensions:
     fetch-titles: true   # default: false; requires network access
 ```
 
+### Surrounding Characters and Groups
+
+References are recognised even when wrapped in brackets or punctuation, for example `(#1)`, `[#1]`, `"#1"`, `#1.`, `something(#1)`, and `.(#1).`.
+
+Comma-separated groups of references inside a single bracket pair are also recognised, both with and without spaces, for example `(#2, #3)`, `(#1, #2, #3)`, `(#2,#3)`, and a bare `#2,#3`.
+A group is linked only when every item is a valid reference, so text such as `1,000` is left untouched.
+
 ### Drafts and Templates
 
 To opt out of all link rewriting for a single document (for example, in a draft or template), set:

--- a/_extensions/gitlink/_modules/string.lua
+++ b/_extensions/gitlink/_modules/string.lua
@@ -98,6 +98,68 @@ function M.strip_surrounding(text)
   return "", text, ""
 end
 
+--- Peel unbalanced surrounding brackets and trailing punctuation from a token.
+--- Unlike `strip_surrounding`, this does not require a balanced pair: it removes
+--- any run of leading opening-bracket characters and any run of trailing
+--- closing-bracket or punctuation characters. This handles bracket groups that
+--- Pandoc split across whitespace, e.g. "(#2," and "#3)" from "(#2, #3)".
+--- Leading set: ( [ { " ' ` and the 2-byte UTF-8 « (\xC2\xAB).
+--- Trailing set: ) ] } " ' ` , . ; : ! ? and the 2-byte UTF-8 » (\xC2\xBB).
+--- @param text string The input text
+--- @return string prefix Characters peeled from the start (may be empty)
+--- @return string inner The inner text after peeling
+--- @return string suffix Characters peeled from the end (may be empty)
+function M.strip_edges(text)
+  if not text or text == "" then
+    return "", text or "", ""
+  end
+
+  local leading = {
+    ["("] = true, ["["] = true, ["{"] = true,
+    ['"'] = true, ["'"] = true, ["`"] = true,
+  }
+  local trailing = {
+    [")"] = true, ["]"] = true, ["}"] = true,
+    ['"'] = true, ["'"] = true, ["`"] = true,
+    [","] = true, ["."] = true, [";"] = true,
+    [":"] = true, ["!"] = true, ["?"] = true,
+  }
+
+  local first = 1
+  local last = #text
+  local prefix = ""
+  local suffix = ""
+
+  while first <= last do
+    if text:sub(first, first + 1) == "\xC2\xAB" then
+      prefix = prefix .. "\xC2\xAB"
+      first = first + 2
+    elseif leading[text:sub(first, first)] then
+      prefix = prefix .. text:sub(first, first)
+      first = first + 1
+    else
+      break
+    end
+  end
+
+  while last >= first do
+    -- The two-byte window can only match a real «/» pair: the leading loop
+    -- never leaves \xC2 at first - 1 (openers are ASCII or the \xAB of a peeled
+    -- «), so the guillemet check cannot straddle the already-peeled prefix.
+    if last >= 2 and text:sub(last - 1, last) == "\xC2\xBB" then
+      suffix = "\xC2\xBB" .. suffix
+      last = last - 2
+    elseif trailing[text:sub(last, last)] then
+      suffix = text:sub(last, last) .. suffix
+      last = last - 1
+    else
+      break
+    end
+  end
+
+  return prefix, text:sub(first, last), suffix
+end
+
 --- Find a balanced bracket pair anywhere in the text and split around it.
 --- Walks the text from `start_pos` looking for an opening bracket whose matching
 --- closing bracket appears later in the string. Returns the text split into

--- a/_extensions/gitlink/gitlink.lua
+++ b/_extensions/gitlink/gitlink.lua
@@ -755,6 +755,62 @@ local function process_commits(elem, current_platform, current_base_url)
   return nil, nil, nil
 end
 
+--- Try the issue/MR, commit, and user matchers on a single token's text.
+--- @param text string The token text to match
+--- @return pandoc.Link|pandoc.Span|nil A link, a badge span, or nil
+local function match_single(text)
+  local elem = pandoc.Str(text)
+  return process_issues_and_mrs(elem, platform, base_url)
+    or process_commits(elem, platform, base_url)
+    or process_users(elem, platform)
+end
+
+--- Match a token's text as a single reference or a comma-separated group.
+--- First tries a whole-text match. If that fails and the text is a
+--- comma-separated group (two or more segments), matches every segment; the
+--- group is recognised only when *all* segments are valid references, so mixed
+--- text such as "1,000" or "#1,note" is left untouched. Comma separators are
+--- preserved as literal `Str` inlines.
+--- @param text string The token text (already stripped of surrounding brackets)
+--- @return pandoc.Link|pandoc.Span|pandoc.List|nil A link, a badge span, a list of inlines, or nil
+local function match_reference_group(text)
+  local link = match_single(text)
+  if link then
+    return link
+  end
+
+  if not text:find(",", 1, true) then
+    return nil
+  end
+
+  local links = {}
+  local count = 0
+  for segment in (text .. ","):gmatch("([^,]*),") do
+    if segment == "" then
+      return nil
+    end
+    local seg_link = match_single(segment)
+    if not seg_link then
+      return nil
+    end
+    count = count + 1
+    links[count] = seg_link
+  end
+
+  if count < 2 then
+    return nil
+  end
+
+  local result = pandoc.List({})
+  for i = 1, count do
+    if i > 1 then
+      result:insert(pandoc.Str(","))
+    end
+    result:insert(links[i])
+  end
+  return result
+end
+
 --- Main Git hosting processing function
 --- Attempts to convert string elements into Git hosting links by trying different patterns
 --- @param elem pandoc.Str The string element to process
@@ -776,30 +832,31 @@ local function process_gitlink(elem)
     end
   end
 
-  -- Fast path: try matching the raw text directly
-  local link = process_issues_and_mrs(elem, platform, base_url)
-    or process_commits(elem, platform, base_url)
-    or process_users(elem, platform)
-
+  -- Fast path: match the raw text directly, including bare comma-separated
+  -- groups such as "#2,#3".
+  local link = match_reference_group(elem.text)
   if link then
     return link
   end
 
-  -- Slow path: strip one layer of surrounding punctuation and retry
-  local prefix, inner, suffix = str.strip_surrounding(elem.text)
+  -- Slow path: peel unbalanced surrounding brackets and trailing punctuation
+  -- and retry. This also handles bracket groups that Pandoc split across
+  -- whitespace, e.g. "(#2," and "#3)" from "(#2, #3)", and single-token groups
+  -- such as "(#2,#3)".
+  local prefix, inner, suffix = str.strip_edges(elem.text)
   if prefix ~= "" or suffix ~= "" then
     if inner ~= "" then
-      local inner_elem = pandoc.Str(inner)
-      link = process_issues_and_mrs(inner_elem, platform, base_url)
-        or process_commits(inner_elem, platform, base_url)
-        or process_users(inner_elem, platform)
-
+      link = match_reference_group(inner)
       if link then
         local result = pandoc.List({})
         if prefix ~= "" then
           result:insert(pandoc.Str(prefix))
         end
-        result:insert(link)
+        if pandoc.utils.type(link) == "List" then
+          result:extend(link)
+        else
+          result:insert(link)
+        end
         if suffix ~= "" then
           result:insert(pandoc.Str(suffix))
         end
@@ -811,7 +868,7 @@ local function process_gitlink(elem)
   -- Embedded path: scan for a bracket pair anywhere inside the token and
   -- retry the matchers on the bracket content. Handles cases where the
   -- bracket is surrounded by additional text or punctuation, e.g.
-  -- "something(#1)", "(#1).", ".(#1).", "(#1)something".
+  -- "something(#1)", "(#1).", ".(#1).", "(#1)something", "something(#1,#2)".
   local search_pos = 1
   while true do
     local b_prefix, b_content, b_suffix, open_pos = str.find_bracketed_content(elem.text, search_pos)
@@ -819,17 +876,17 @@ local function process_gitlink(elem)
       break
     end
 
-    local content_elem = pandoc.Str(b_content)
-    local content_link = process_issues_and_mrs(content_elem, platform, base_url)
-      or process_commits(content_elem, platform, base_url)
-      or process_users(content_elem, platform)
-
+    local content_link = match_reference_group(b_content)
     if content_link then
       local result = pandoc.List({})
       if b_prefix ~= "" then
         result:insert(pandoc.Str(b_prefix))
       end
-      result:insert(content_link)
+      if pandoc.utils.type(content_link) == "List" then
+        result:extend(content_link)
+      else
+        result:insert(content_link)
+      end
       if b_suffix ~= "" then
         result:insert(pandoc.Str(b_suffix))
       end

--- a/example.qmd
+++ b/example.qmd
@@ -102,6 +102,12 @@ References with surrounding characters:
 - Bracket with leading and trailing text: something(#1)something
 - Bracket with cross-repository issue and trailing text: (mcanouil/quarto-gitlink#1)something
 - Bracket with GitHub-style issue and surrounding text: see(GH-1)now
+- Parenthesised group of two issues: (#2, #3)
+- Parenthesised group of three issues: (#1, #2, #3)
+- Parenthesised group of cross-repository issues: (mcanouil/quarto-gitlink#1, mcanouil/quarto-gitlink#2)
+- Parenthesised group without spaces: (#2,#3)
+- Parenthesised group of three without spaces: (#1,#2,#3)
+- Bare group without spaces: #2,#3
 - Bracket with commit and trailing punctuation: see(cb0350d0316d1c420508338d02e56f5c8f907226).
 
 Full URL examples (automatically shortened):


### PR DESCRIPTION
References grouped inside a single bracket pair were not converted to links. Pandoc splits on whitespace, so a group such as `(#2, #3)` becomes the tokens `(#2,` and `#3)`, each carrying an unbalanced bracket edge that no matching path handled. A no-space group like `(#2,#3)` stayed a single token that the anchored matchers rejected because of the embedded comma.

The slow path now peels unbalanced leading and trailing brackets and punctuation with a new `strip_edges` helper, and a new `match_reference_group` helper links a comma-separated group only when every item is a valid reference, preserving the commas as literal text. Both the spaced and no-space forms are recognised, including when the group sits inside surrounding text via the embedded-bracket path. Mixed content such as `1,000` is left untouched.

`example.qmd`, the README, and the changelog document the new behaviour.