### PR TITLE
feat: support the repository widget in the sidebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,8 @@
 /test/widget-site/_site/
 /test/widget-site/.quarto/
 /test/widget-site/_extensions/
+/test/sidebar-site/_site/
+/test/sidebar-site/.quarto/
+/test/sidebar-site/_extensions/
 __pycache__/
 /tools/.venv/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### New Features
+
+- feat: Support the repository widget in the sidebar of book-like sites (`navbar: false`), as a `sidebar.tools` entry or a `sidebar.contents` item; a tool widget sits below the colour-scheme and reader toggles and above search on its own centred line with an overlay menu, while a contents widget spans the sidebar width and expands its menu inline so the sidebar scroll area never clips it.
+- feat: Replace every `#gitlink-widget` placeholder on a page instead of only the first, with unique element ids per widget and a single shared stats request.
+
 ## 1.8.0 (2026-07-24)
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -267,9 +267,9 @@ extensions:
 - `badge-background-colour`: Set the background colour (hex code or colour name). Defaults to `#c3c3c3` (grey).
 - `badge-text-colour`: Set the text colour (hex code or colour name). If not specified, uses the default text colour.
 
-### Repository Navbar Widget
+### Repository Widget
 
-For Quarto **websites** (HTML output), gitlink can replace a navbar item with a repository widget: a button showing live star and fork counts (fetched from the platform API, cached in `localStorage` for four hours) that opens a dropdown of repository links.
+For Quarto **websites** (HTML output), gitlink can replace a navigation item with a repository widget: a button showing live star and fork counts (fetched from the platform API, cached in `localStorage` for four hours) that opens a dropdown of repository links.
 
 Add a placeholder navbar item with href `#gitlink-widget` to `_quarto.yml`:
 
@@ -290,6 +290,27 @@ extensions:
     widget:
       enabled: true
 ```
+
+Book-like sites without a navbar work the same way: put the placeholder in the sidebar, either as a tool or as a contents item (both may be used at once, and every placeholder on a page becomes a widget):
+
+```yaml
+website:
+  navbar: false
+  sidebar:
+    style: docked
+    search: true
+    tools:
+      - text: "GitHub"
+        icon: github
+        href: "#gitlink-widget"
+    contents:
+      - text: Home
+        href: index.qmd
+      - text: "Repository"
+        href: "#gitlink-widget"
+```
+
+In the sidebar, a tool widget sits below the colour-scheme and reader toggles and above the search field, on its own centred line, and opens an overlay menu; a contents widget spans the sidebar width and expands its menu inline, so the sidebar scroll area never clips it.
 
 The default dropdown contains Repository, Issues, Pull Requests (Merge Requests on GitLab), Releases, Add a Star, and Create a Fork, based on what the platform supports. Customise it with:
 
@@ -324,7 +345,7 @@ For any other icon, put a shortcode in the entry's `text` instead, for example w
 
 The widget's appearance follows Bootstrap tokens by default and can be themed via CSS custom properties: `--gitlink-widget-border`, `--gitlink-widget-accent`, `--gitlink-widget-accent-soft`, `--gitlink-widget-pill-bg`, `--gitlink-widget-menu-bg`, and `--gitlink-widget-menu-fg`.
 
-The widget sizes Quarto's navbar search button and colour-scheme toggle to match its trigger, with consistent spacing across the navbar-right control group; `style-navbar-tools` additionally paints both with the widget's bordered pill style.
+The widget sizes Quarto's navbar search button and colour-scheme toggle to match its trigger, with consistent spacing across the navbar-right control group; `style-navbar-tools` additionally paints both with the widget's bordered pill style. Both options apply to the navbar only; sidebar tools keep Quarto's own styling.
 
 The widget works independently of link rewriting: set `enabled: false` alongside `widget.enabled: true` to use only the widget. On Bitbucket the widget renders without counters, as its API exposes no star count.
 
@@ -555,5 +576,5 @@ Output of `example.qmd`:
 
 ---
 
-The repository navbar widget is inspired by and derived from the GitHub button in [posit-dev/great-docs](https://github.com/posit-dev/great-docs) by [Rich Iannone](https://github.com/rich-iannone).
+The repository widget is inspired by and derived from the GitHub button in [posit-dev/great-docs](https://github.com/posit-dev/great-docs) by [Rich Iannone](https://github.com/rich-iannone).
 Embedded icons are 16px bodies from [primer/octicons](https://github.com/primer/octicons) (MIT License, GitHub Inc.).

--- a/_extensions/gitlink/_modules/widget.lua
+++ b/_extensions/gitlink/_modules/widget.lua
@@ -23,7 +23,7 @@ local log = load_sibling('logging.lua')
 local html_mod = load_sibling('html.lua')
 
 --- @type string Version used for the injected HTML dependency
-local WIDGET_DEPENDENCY_VERSION = '1.7.0'
+local WIDGET_DEPENDENCY_VERSION = '1.9.0'
 
 --- @type table<string, string>|nil Octicon SVG bodies by name (loaded once per render)
 local octicons_cache = nil

--- a/_extensions/gitlink/_schema.yml
+++ b/_extensions/gitlink/_schema.yml
@@ -81,12 +81,12 @@ options:
       type: string
   widget:
     type: object
-    description: "Repository navbar widget showing live star/fork counts and a dropdown of repository links, replacing a navbar item with href '#gitlink-widget'. HTML websites only."
+    description: "Repository widget showing live star/fork counts and a dropdown of repository links, replacing every navbar item, sidebar tool, or sidebar contents item with href '#gitlink-widget'. HTML websites only."
     properties:
       enabled:
         type: boolean
         default: false
-        description: "Whether to inject the navbar widget. Independent of the top-level 'enabled' option, so a site can run widget-only."
+        description: "Whether to inject the widget. Independent of the top-level 'enabled' option, so a site can run widget-only."
       links:
         type: object
         description: "Toggles for the platform-derived default menu entries."

--- a/_extensions/gitlink/widget.css
+++ b/_extensions/gitlink/widget.css
@@ -220,9 +220,10 @@
 
 /* A tools row holding the widget stacks vertically: the widget trigger is a
    counted pill, not an icon, so it takes its own line above the remaining
-   tools (colour-scheme toggle, reader toggle, overlay search). */
-.sidebar-tools-main.gitlink-widget-tools,
-.sidebar-tools-collapse.gitlink-widget-tools {
+   tools (colour-scheme toggle, reader toggle, overlay search). The marker
+   class is set by widget.js on whichever tools container the placeholder
+   was in. */
+.gitlink-widget-tools {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -251,27 +252,22 @@
    be laid out as another flex item beside them. Keep the overlay menu there,
    anchored to the trigger's left edge so it stays inside the sidebar width
    (this is what Quarto's own sidebar tool dropdowns do). */
-.sidebar-tools-main .gitlink-widget-sidebar,
-.sidebar-tools-collapse .gitlink-widget-sidebar {
+.gitlink-widget-tools .gitlink-widget-sidebar {
   display: inline-flex;
-  flex-direction: row;
   width: auto;
 }
 
-.sidebar-tools-main .gitlink-widget-sidebar .gitlink-widget-trigger,
-.sidebar-tools-collapse .gitlink-widget-sidebar .gitlink-widget-trigger {
+.gitlink-widget-tools .gitlink-widget-sidebar .gitlink-widget-trigger {
   width: auto;
 }
 
 /* The menu keeps its content width (no 14rem floor) so it stays inside the
    sidebar, which clips overflow rather than scrolling sideways. */
-.sidebar-tools-main .gitlink-widget-sidebar .gitlink-widget-dropdown,
-.sidebar-tools-collapse .gitlink-widget-sidebar .gitlink-widget-dropdown {
+.gitlink-widget-tools .gitlink-widget-sidebar .gitlink-widget-dropdown {
   position: absolute;
   display: block;
   left: 0;
   right: auto;
-  min-width: 0;
   width: max-content;
   margin-top: 0;
   box-shadow: 0 12px 30px -16px rgba(0, 0, 0, 0.55);

--- a/_extensions/gitlink/widget.css
+++ b/_extensions/gitlink/widget.css
@@ -1,9 +1,9 @@
-/* Gitlink repository navbar widget.
+/* Gitlink repository navigation widget (navbar or sidebar).
    Structural styling only; theming happens through the `--gitlink-widget-*`
    custom properties, which fall back to Bootstrap tokens so unthemed Quarto
    sites work out of the box. */
 
-#gitlink-widget {
+.gitlink-widget {
   position: relative;
   display: inline-flex;
   align-items: center;
@@ -123,9 +123,10 @@
   transform: rotate(180deg);
 }
 
-/* Menu rules are scoped under `.navbar` so they outrank Quarto's `.navbar a`
-   colour, which would otherwise force the navbar foreground onto the items. */
-.navbar .gitlink-widget-dropdown {
+/* Menu rules are scoped under `.gitlink-widget` so they outrank Quarto's
+   `.navbar a` and `.sidebar-navigation a` colours, which would otherwise
+   force the surrounding navigation foreground onto the items. */
+.gitlink-widget .gitlink-widget-dropdown {
   position: absolute;
   top: calc(100% + 6px);
   right: 0;
@@ -142,13 +143,13 @@
   z-index: 1000;
 }
 
-.navbar .gitlink-widget-open .gitlink-widget-dropdown {
+.gitlink-widget.gitlink-widget-open .gitlink-widget-dropdown {
   opacity: 1;
   visibility: visible;
   transform: translateY(0);
 }
 
-.navbar .gitlink-widget-item {
+.gitlink-widget .gitlink-widget-item {
   display: flex;
   align-items: center;
   gap: 10px;
@@ -161,30 +162,119 @@
   transition: background 150ms ease, color 150ms ease;
 }
 
-.navbar .gitlink-widget-item svg,
-.navbar .gitlink-widget-item .bi {
+.gitlink-widget .gitlink-widget-item svg,
+.gitlink-widget .gitlink-widget-item .bi {
   flex-shrink: 0;
 }
 
 /* Labels may carry inline markup (e.g. an iconify icon from a shortcode in
    the entry's `text`); keep any such icon aligned with the text. */
-.navbar .gitlink-widget-item .gitlink-widget-item-label {
+.gitlink-widget .gitlink-widget-item .gitlink-widget-item-label {
   display: inline-flex;
   align-items: center;
   gap: 6px;
 }
 
-.navbar .gitlink-widget-item:hover,
-.navbar .gitlink-widget-item:focus-visible {
+.gitlink-widget .gitlink-widget-item:hover,
+.gitlink-widget .gitlink-widget-item:focus-visible {
   background: var(--gitlink-widget-accent-soft, color-mix(in srgb, var(--gitlink-widget-accent, var(--bs-link-color, #0d6efd)) 15%, transparent));
   color: var(--gitlink-widget-accent, var(--bs-link-color, #0d6efd));
   text-decoration: none;
 }
 
-.navbar .gitlink-widget-divider {
+.gitlink-widget .gitlink-widget-divider {
   height: 1px;
   margin: 0.35rem 0;
   background: var(--gitlink-widget-border, var(--bs-border-color-translucent, rgba(128, 128, 128, 0.3)));
+}
+
+/* Sidebar placements (`sidebar.tools` and `sidebar.contents`). Quarto's
+   sidebar is an `overflow-auto` scroll container, which would clip an
+   absolutely positioned menu, so the menu expands inline below the trigger
+   instead, like a sidebar section. */
+.gitlink-widget-sidebar {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  width: 100%;
+}
+
+.gitlink-widget-sidebar .gitlink-widget-trigger {
+  width: 100%;
+  justify-content: space-between;
+}
+
+.gitlink-widget-sidebar .gitlink-widget-dropdown {
+  position: static;
+  display: none;
+  min-width: 0;
+  width: 100%;
+  margin-top: 0.35rem;
+  box-shadow: none;
+  transform: none;
+}
+
+.gitlink-widget-sidebar.gitlink-widget-open .gitlink-widget-dropdown {
+  display: block;
+}
+
+/* A tools row holding the widget stacks vertically: the widget trigger is a
+   counted pill, not an icon, so it takes its own line above the remaining
+   tools (colour-scheme toggle, reader toggle, overlay search). */
+.sidebar-tools-main.gitlink-widget-tools,
+.sidebar-tools-collapse.gitlink-widget-tools {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+  width: 100%;
+}
+
+/* Quarto pulls the tools row up under the sidebar title (`margin-top: -6px`),
+   which crowds the widget pill; give it room instead. */
+.sidebar-title .sidebar-tools-main.gitlink-widget-tools {
+  margin-top: 0.5rem;
+}
+
+/* The widget sits below the icon tools (colour-scheme and reader toggles) and
+   above the search control, whether search is the sidebar field below the row
+   or an overlay button inside it. */
+.gitlink-widget-tools .gitlink-widget {
+  order: 1;
+}
+
+.gitlink-widget-tools #quarto-search {
+  order: 2;
+}
+
+/* A tool sits in a strip of icon-sized controls, where an inline menu would
+   be laid out as another flex item beside them. Keep the overlay menu there,
+   anchored to the trigger's left edge so it stays inside the sidebar width
+   (this is what Quarto's own sidebar tool dropdowns do). */
+.sidebar-tools-main .gitlink-widget-sidebar,
+.sidebar-tools-collapse .gitlink-widget-sidebar {
+  display: inline-flex;
+  flex-direction: row;
+  width: auto;
+}
+
+.sidebar-tools-main .gitlink-widget-sidebar .gitlink-widget-trigger,
+.sidebar-tools-collapse .gitlink-widget-sidebar .gitlink-widget-trigger {
+  width: auto;
+}
+
+/* The menu keeps its content width (no 14rem floor) so it stays inside the
+   sidebar, which clips overflow rather than scrolling sideways. */
+.sidebar-tools-main .gitlink-widget-sidebar .gitlink-widget-dropdown,
+.sidebar-tools-collapse .gitlink-widget-sidebar .gitlink-widget-dropdown {
+  position: absolute;
+  display: block;
+  left: 0;
+  right: auto;
+  min-width: 0;
+  width: max-content;
+  margin-top: 0;
+  box-shadow: 0 12px 30px -16px rgba(0, 0, 0, 0.55);
 }
 
 /* The collapsed navbar-nav is a Bootstrap `.navbar-nav-scroll` region
@@ -197,7 +287,7 @@
     overflow: visible;
   }
 
-  .navbar .gitlink-widget-dropdown {
+  .navbar .gitlink-widget .gitlink-widget-dropdown {
     left: 0;
     right: auto;
   }

--- a/_extensions/gitlink/widget.js
+++ b/_extensions/gitlink/widget.js
@@ -356,8 +356,11 @@
 
     let replacement = root;
     if (slot.tagName === "LI") {
+      // Keep the list item's own classes (`nav-item` in a navbar,
+      // `sidebar-item` in a sidebar) so the widget inherits the spacing of
+      // the items around it.
       replacement = document.createElement("li");
-      replacement.className = "nav-item";
+      replacement.className = slot.className;
       replacement.appendChild(root);
     }
     slot.replaceWith(replacement);

--- a/_extensions/gitlink/widget.js
+++ b/_extensions/gitlink/widget.js
@@ -1,13 +1,14 @@
 /**
- * Gitlink - Repository Navbar Widget
- * Replaces the `#gitlink-widget` navbar placeholder with a button showing live
- * star and fork counts and a dropdown menu of repository links. Configuration
- * is injected by the gitlink Lua filter as a JSON script element; counts come
- * from the platform REST API, cached in localStorage for four hours so the
- * rate limit is not hit on every page view. A stale cache or `?` covers a
- * failed request. Octicon path data for the icons the menu uses arrives in
- * the configuration (`icons`); other icon names render as Bootstrap Icons,
- * which Quarto bundles with every HTML page.
+ * Gitlink - Repository Navigation Widget
+ * Replaces every `#gitlink-widget` placeholder (navbar item, sidebar tool, or
+ * sidebar contents item) with a button showing live star and fork counts and a
+ * dropdown menu of repository links. Configuration is injected by the gitlink
+ * Lua filter as a JSON script element; counts come from the platform REST API,
+ * cached in localStorage for four hours so the rate limit is not hit on every
+ * page view, and shared by every widget on the page. A stale cache or `?`
+ * covers a failed request. Octicon path data for the icons the menu uses
+ * arrives in the configuration (`icons`); other icon names render as Bootstrap
+ * Icons, which Quarto bundles with every HTML page.
  *
  * @license MIT
  * @copyright 2026 Mickaël Canouil
@@ -164,12 +165,12 @@
   // Disclosure pattern: a native button toggling a plain list of links, per
   // the ARIA Authoring Practices for navigation link collections. No menu
   // roles, so Tab moves through the links naturally.
-  const buildTrigger = (config) => {
+  const buildTrigger = (config, menuId) => {
     const trigger = document.createElement("button");
     trigger.type = "button";
     trigger.className = "gitlink-widget-trigger";
     trigger.setAttribute("aria-expanded", "false");
-    trigger.setAttribute("aria-controls", "gitlink-widget-menu");
+    trigger.setAttribute("aria-controls", menuId);
     trigger.setAttribute("aria-label", config.menuLabel);
 
     const platformIcon = buildIcon(config.icon, 20, config.icons);
@@ -192,9 +193,9 @@
     return trigger;
   };
 
-  const buildDropdown = (config) => {
+  const buildDropdown = (config, menuId) => {
     const dropdown = document.createElement("div");
-    dropdown.id = "gitlink-widget-menu";
+    dropdown.id = menuId;
     dropdown.className = "gitlink-widget-dropdown";
     dropdown.setAttribute("aria-hidden", "true");
 
@@ -227,15 +228,17 @@
     return dropdown;
   };
 
-  const buildWidget = (config) => {
-    const widget = document.createElement("li");
-    widget.className = "nav-item";
+  // The first widget on a page keeps the historical `gitlink-widget` id; any
+  // further placeholder gets a suffixed one so ids stay unique.
+  const buildWidget = (config, index) => {
+    const rootId = index === 0 ? "gitlink-widget" : "gitlink-widget-" + index;
+    const menuId = rootId + "-menu";
     const root = document.createElement("div");
-    root.id = "gitlink-widget";
-    root.appendChild(buildTrigger(config));
-    root.appendChild(buildDropdown(config));
-    widget.appendChild(root);
-    return widget;
+    root.id = rootId;
+    root.className = "gitlink-widget";
+    root.appendChild(buildTrigger(config, menuId));
+    root.appendChild(buildDropdown(config, menuId));
+    return root;
   };
 
   const showStats = (widget, stats, config) => {
@@ -259,17 +262,19 @@
     }
   };
 
-  const loadStats = (widget, config) => {
-    if (!config.api) return;
+  // In-flight requests by cache key, so several placeholders on one page share
+  // a single API call instead of racing each other before the cache is written.
+  const statsRequests = new Map();
 
+  const fetchStats = (config) => {
     // Read + parse the cache once; branch on freshness so the stale-fallback
     // path does not re-read and re-parse the same entry.
     const cached = readCache(config.cacheKey);
     if (cached && Date.now() - cached.timestamp <= CACHE_DURATION) {
-      showStats(widget, cached, config);
-      return;
+      return Promise.resolve(cached);
     }
-    const stale = cached;
+    const pending = statsRequests.get(config.cacheKey);
+    if (pending) return pending;
 
     const options = { headers: config.api.headers || {} };
     // Bound the request so a slow API falls back to the stale cache instead
@@ -278,7 +283,7 @@
       options.signal = AbortSignal.timeout(8000);
     }
 
-    fetch(config.api.endpoint, options)
+    const request = fetch(config.api.endpoint, options)
       .then((response) => (response.ok ? response.json() : Promise.reject(response.status)))
       .then((data) => {
         const stats = {
@@ -287,9 +292,16 @@
           timestamp: Date.now(),
         };
         writeCache(config.cacheKey, stats);
-        showStats(widget, stats, config);
+        return stats;
       })
-      .catch(() => showStats(widget, stale || { stars: "?", forks: "?" }, config));
+      .catch(() => cached || { stars: "?", forks: "?" });
+    statsRequests.set(config.cacheKey, request);
+    return request;
+  };
+
+  const loadStats = (widget, config) => {
+    if (!config.api) return;
+    fetchStats(config).then((stats) => showStats(widget, stats, config));
   };
 
   const setupDropdown = (widget) => {
@@ -324,6 +336,36 @@
     });
   };
 
+  // Replace one placeholder anchor with a widget. Navbar and sidebar contents
+  // items sit in an `<li>`, which is replaced whole so the surrounding list
+  // markup is preserved; a sidebar tool is a bare anchor in
+  // `div.sidebar-tools-main`, so the anchor itself is replaced.
+  const mountWidget = (anchor, index, config) => {
+    const slot = anchor.closest("li") || anchor;
+    const root = buildWidget(config, index);
+    if (anchor.closest("#quarto-sidebar")) {
+      root.classList.add("gitlink-widget-sidebar");
+    }
+    // The tools row is a horizontal strip of icon-sized controls; flag it so
+    // the CSS can stack the widget above the search and colour-scheme
+    // controls instead of squeezing the counts in beside them.
+    const tools = anchor.closest(".sidebar-tools-main, .sidebar-tools-collapse");
+    if (tools) {
+      tools.classList.add("gitlink-widget-tools");
+    }
+
+    let replacement = root;
+    if (slot.tagName === "LI") {
+      replacement = document.createElement("li");
+      replacement.className = "nav-item";
+      replacement.appendChild(root);
+    }
+    slot.replaceWith(replacement);
+
+    loadStats(root, config);
+    setupDropdown(root);
+  };
+
   document.addEventListener("DOMContentLoaded", function () {
     const config = readConfig();
     if (!config) return;
@@ -331,14 +373,7 @@
     // Quarto rewrites the placeholder href to a relative path
     // (`./#gitlink-widget` at the root, `../#gitlink-widget` deeper), so
     // match the fragment suffix rather than an exact href.
-    const anchor = document.querySelector('a[href$="#gitlink-widget"]');
-    if (!anchor) return;
-    const slot = anchor.closest("li");
-    if (!slot) return;
-
-    const widget = buildWidget(config);
-    slot.replaceWith(widget);
-    loadStats(widget, config);
-    setupDropdown(widget);
+    const anchors = document.querySelectorAll('a[href$="#gitlink-widget"]');
+    anchors.forEach((anchor, index) => mountWidget(anchor, index, config));
   });
 })();

--- a/test/sidebar-site/.gitignore
+++ b/test/sidebar-site/.gitignore
@@ -1,0 +1,2 @@
+/.quarto/
+**/*.quarto_ipynb

--- a/test/sidebar-site/_quarto.yml
+++ b/test/sidebar-site/_quarto.yml
@@ -1,0 +1,64 @@
+project:
+  type: website
+  # Transient copy of the extension so the filter resolves like a real
+  # installation; removed again after render. Entries run without a shell,
+  # so one command per line, and the copy is an idempotent overlay so no
+  # destructive command runs before the render.
+  pre-render:
+    - mkdir -p _extensions/gitlink
+    - cp -R ../../_extensions/gitlink/. _extensions/gitlink/
+  post-render:
+    - rm -rf _extensions
+
+website:
+  title: "Gitlink Sidebar Test"
+  navbar: false
+  sidebar:
+    title: "Gitlink Sidebar Test"
+    style: docked
+    search: true
+    pinned: true
+    collapse-level: 2
+    tools:
+      - text: "GitHub"
+        icon: github
+        href: "#gitlink-widget"
+    contents:
+      - text: Home
+        href: index.qmd
+      - text: Program
+        href: program/index.qmd
+      - text: "---"
+      - section: "Part 1"
+        contents:
+          - href: sessions/01-introduction-setup/index.qmd
+          - href: sessions/02-authoring-essentials/index.qmd
+      - text: "---"
+      - text: "Repository"
+        href: "#gitlink-widget"
+
+format:
+  html:
+    theme:
+      light: flatly
+      dark: darkly
+
+filters:
+  - gitlink
+
+extensions:
+  gitlink:
+    platform: github
+    repository-name: mcanouil/quarto-gitlink
+    widget:
+      enabled: true
+      links:
+        discussions: true
+      extra-links:
+        - text: "Q&A"
+          href: "/discussions/categories/q-a"
+          icon: question
+        - text: "Quarto"
+          href: "https://quarto.org"
+          icon: globe
+      sponsor: mcanouil

--- a/test/sidebar-site/index.qmd
+++ b/test/sidebar-site/index.qmd
@@ -1,0 +1,13 @@
+---
+title: "Sidebar widget test: home"
+---
+
+This site has no navbar, so both gitlink widgets live in the docked sidebar.
+
+Under the sidebar title, the widget should sit below the colour-scheme toggle and above the search field, centred, showing live star and fork counts for mcanouil/quarto-gitlink; the "Repository" entry at the bottom of the sidebar contents should show a second, full-width widget.
+
+The tools widget opens an overlay menu, the contents widget expands its menu inline; both must stay inside the sidebar width (no horizontal clipping) and read correctly in light and dark themes.
+
+Link rewriting is active on this page, so #1 and mcanouil/quarto-cli#2 should be links.
+
+Expected dropdown: Repository, Issues, Pull Requests, Releases, Discussions, divider, Add a Star, Create a Fork, divider, Q&A, Quarto, Sponsor.

--- a/test/sidebar-site/program/index.qmd
+++ b/test/sidebar-site/program/index.qmd
@@ -1,0 +1,7 @@
+---
+title: "Program"
+---
+
+A page one level deep: Quarto rewrites the placeholder href to `../#gitlink-widget`, so both widgets must still mount here.
+
+Link rewriting is active, so #42 should be a link.

--- a/test/sidebar-site/sessions/01-introduction-setup/index.qmd
+++ b/test/sidebar-site/sessions/01-introduction-setup/index.qmd
@@ -1,0 +1,7 @@
+---
+title: "Session 1: Introduction and setup"
+---
+
+A page two levels deep, inside a collapsible sidebar section.
+
+Both widgets must mount, and the section collapse must keep working around the "Repository" widget below it.

--- a/test/sidebar-site/sessions/02-authoring-essentials/index.qmd
+++ b/test/sidebar-site/sessions/02-authoring-essentials/index.qmd
@@ -1,0 +1,10 @@
+---
+title: "Session 2: Authoring essentials"
+extensions:
+  gitlink:
+    enabled: false
+    widget:
+      enabled: true
+---
+
+Link rewriting is disabled on this page, so #123 must stay plain text, while both sidebar widgets must still be present.


### PR DESCRIPTION
The repository widget only mounted in a navbar: the placeholder anchor had to sit in an `li`, which sidebar tools do not, and every menu rule was scoped under `.navbar`, so a sidebar placement rendered unstyled. Book-like sites that set `navbar: false` and put all navigation in a docked sidebar therefore could not use it.

Every `#gitlink-widget` placeholder on a page now becomes a widget, with unique element ids per widget and a single shared stats request instead of one per widget. A `sidebar.tools` placeholder stacks the widget on its own centred line, below the colour-scheme and reader toggles and above search, and opens an overlay menu sized to fit the sidebar; a `sidebar.contents` placeholder spans the sidebar width and expands its menu inline, which the sidebar scroll area would otherwise clip. Navbar placements keep their existing markup and absolute menu.

`test/sidebar-site` is a navbar-less docked-sidebar project covering both placements, link rewriting on and off, and pages one and two levels deep. README, schema descriptions, and the changelog are updated, and the injected widget dependency version is bumped so cached sites pick up the new assets.