### PR TITLE
refactor: mount the widget in place of the placeholder anchor

### DIFF
--- a/_extensions/gitlink/widget.css
+++ b/_extensions/gitlink/widget.css
@@ -188,10 +188,10 @@
   background: var(--gitlink-widget-border, var(--bs-border-color-translucent, rgba(128, 128, 128, 0.3)));
 }
 
-/* Sidebar placements (`sidebar.tools` and `sidebar.contents`). Quarto's
-   sidebar is an `overflow-auto` scroll container, which would clip an
-   absolutely positioned menu, so the menu expands inline below the trigger
-   instead, like a sidebar section. */
+/* Sidebar navigation item (`sidebar.contents`). Quarto's sidebar is an
+   `overflow-auto` scroll container, which would clip an absolutely positioned
+   menu, so the menu expands inline below the trigger, like a sidebar section.
+   `display` is not animatable, hence no transition. */
 .gitlink-widget-sidebar {
   display: flex;
   flex-direction: column;
@@ -212,6 +212,7 @@
   margin-top: 0.35rem;
   box-shadow: none;
   transform: none;
+  transition: none;
 }
 
 .gitlink-widget-sidebar.gitlink-widget-open .gitlink-widget-dropdown {
@@ -221,9 +222,10 @@
 /* A tools row holding the widget stacks vertically: the widget trigger is a
    counted pill, not an icon, so it takes its own line above the remaining
    tools (colour-scheme toggle, reader toggle, overlay search). The marker
-   class is set by widget.js on whichever tools container the placeholder
-   was in. */
-.gitlink-widget-tools {
+   class is set by widget.js on whichever tools container the placeholder was
+   in; the id keeps this ahead of Quarto's own `.sidebar-tools-main` rather
+   than relying on stylesheet order. */
+#quarto-sidebar .gitlink-widget-tools {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -249,28 +251,15 @@
 }
 
 /* A tool sits in a strip of icon-sized controls, where an inline menu would
-   be laid out as another flex item beside them. Keep the overlay menu there,
-   anchored to the trigger's left edge so it stays inside the sidebar width
-   (this is what Quarto's own sidebar tool dropdowns do). */
-.gitlink-widget-tools .gitlink-widget-sidebar {
-  display: inline-flex;
-  width: auto;
-}
-
-.gitlink-widget-tools .gitlink-widget-sidebar .gitlink-widget-trigger {
-  width: auto;
-}
-
-/* The menu keeps its content width (no 14rem floor) so it stays inside the
-   sidebar, which clips overflow rather than scrolling sideways. */
-.gitlink-widget-tools .gitlink-widget-sidebar .gitlink-widget-dropdown {
-  position: absolute;
-  display: block;
+   be laid out as another flex item beside them, so it keeps the overlay menu.
+   The menu is anchored to the trigger's left edge and takes its content width
+   (no 14rem floor) so it stays inside the sidebar, which clips overflow
+   rather than scrolling sideways. */
+.gitlink-widget-tools .gitlink-widget-dropdown {
   left: 0;
   right: auto;
+  min-width: 0;
   width: max-content;
-  margin-top: 0;
-  box-shadow: 0 12px 30px -16px rgba(0, 0, 0, 0.55);
 }
 
 /* The collapsed navbar-nav is a Bootstrap `.navbar-nav-scroll` region

--- a/_extensions/gitlink/widget.js
+++ b/_extensions/gitlink/widget.js
@@ -262,9 +262,10 @@
     }
   };
 
-  // In-flight requests by cache key, so several placeholders on one page share
-  // a single API call instead of racing each other before the cache is written.
-  const statsRequests = new Map();
+  // The in-flight request, shared by every widget on the page (they all read
+  // the same configuration) so several placeholders make one API call instead
+  // of racing each other before the cache is written.
+  let pendingStats = null;
 
   const fetchStats = (config) => {
     // Read + parse the cache once; branch on freshness so the stale-fallback
@@ -273,8 +274,7 @@
     if (cached && Date.now() - cached.timestamp <= CACHE_DURATION) {
       return Promise.resolve(cached);
     }
-    const pending = statsRequests.get(config.cacheKey);
-    if (pending) return pending;
+    if (pendingStats) return pendingStats;
 
     const options = { headers: config.api.headers || {} };
     // Bound the request so a slow API falls back to the stale cache instead
@@ -295,7 +295,7 @@
         return stats;
       })
       .catch(() => cached || { stars: "?", forks: "?" });
-    statsRequests.set(config.cacheKey, request);
+    pendingStats = request;
     return request;
   };
 
@@ -336,34 +336,26 @@
     });
   };
 
-  // Replace one placeholder anchor with a widget. Navbar and sidebar contents
-  // items sit in an `<li>`, which is replaced whole so the surrounding list
-  // markup is preserved; a sidebar tool is a bare anchor in
-  // `div.sidebar-tools-main`, so the anchor itself is replaced.
+  // Replace one placeholder anchor with a widget. Only the anchor goes, so
+  // whatever Quarto wrapped it in (`li.nav-item`, `li.sidebar-item >
+  // div.sidebar-item-container`, `div.sidebar-tools-main`) is preserved, and
+  // the widget inherits the spacing and colours of its neighbours.
   const mountWidget = (anchor, index, config) => {
-    const slot = anchor.closest("li") || anchor;
     const root = buildWidget(config, index);
-    if (anchor.closest("#quarto-sidebar")) {
-      root.classList.add("gitlink-widget-sidebar");
-    }
+
     // The tools row is a horizontal strip of icon-sized controls; flag it so
     // the CSS can stack the widget above the search and colour-scheme
     // controls instead of squeezing the counts in beside them.
     const tools = anchor.closest(".sidebar-tools-main, .sidebar-tools-collapse");
     if (tools) {
       tools.classList.add("gitlink-widget-tools");
+    } else if (anchor.closest("#quarto-sidebar")) {
+      // A sidebar navigation item is as wide as the sidebar and sits in its
+      // scroll container, so its menu expands inline rather than overlaying.
+      root.classList.add("gitlink-widget-sidebar");
     }
 
-    let replacement = root;
-    if (slot.tagName === "LI") {
-      // Keep the list item's own classes (`nav-item` in a navbar,
-      // `sidebar-item` in a sidebar) so the widget inherits the spacing of
-      // the items around it.
-      replacement = document.createElement("li");
-      replacement.className = slot.className;
-      replacement.appendChild(root);
-    }
-    slot.replaceWith(replacement);
+    anchor.replaceWith(root);
 
     loadStats(root, config);
     setupDropdown(root);


### PR DESCRIPTION
Follow-up to #44, all of it internal to the unreleased widget code.

The mount replaced the whole list item around a placeholder, rebuilding the markup Quarto wraps a navigation item in. A sidebar contents item is `li.sidebar-item > div.sidebar-item-container > a`, so the widget landed as a direct child of the list item and missed the container that carries the sidebar colours and flex layout. Replacing only the anchor preserves every wrapper as Quarto rendered it, in all three placements, and removes the list-item lookup, the tag branch, and the class copy.

The inline-menu styling now applies to sidebar navigation items alone. A tools placement previously received it and then had `position`, `display`, `margin-top` and the shadow restored declaration by declaration; it now keeps the base overlay menu and only sets its anchoring and content width. The tools row layout is scoped under `#quarto-sidebar`, so it stays ahead of Quarto`s own `.sidebar-tools-main` rule without depending on stylesheet order, and the inline menu drops a transition it cannot use, since it opens through `display`.

The shared stats request is a single value rather than a map keyed by cache key, since one configuration is read per page.

Verified by rendering `test/sidebar-site` and `test/widget-site` and measuring both placements on every page in a headless browser: unchanged geometry (tools widget and menu, contents widget full width, no sidebar overflow), unique ids, one API request per page, Escape closes and returns focus, and readable colours in light and dark. The contents widget now reports `sidebar-item-container` as its parent, and the navbar widget still sits in `li.nav-item`.