### PR TITLE
fix: keep the sidebar tools widget menu inside the column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- fix: Keep a sidebar tools widget's menu inside the sidebar, so a docked sidebar carrying the widget no longer has a permanent horizontal scrollbar. Quarto's sidebar sets `overflow-y: auto` and leaves `overflow-x` at `visible`, which computes to `auto`, so a menu wider than the column scrolled it sideways instead of being clipped; the menu was anchored to the centred trigger and sized to its content, so it ran past the right edge, and because it is hidden with `visibility` rather than `display` it did so even while shut. The menu is now stretched between both edges of the tools row, which spans the column. The navbar and `sidebar.contents` placements are unaffected.
+
 ## 1.9.0 (2026-07-31)
 
 ### New Features

--- a/_extensions/gitlink/widget.css
+++ b/_extensions/gitlink/widget.css
@@ -224,8 +224,13 @@
    tools (colour-scheme toggle, reader toggle, overlay search). The marker
    class is set by widget.js on whichever tools container the placeholder was
    in; the id keeps this ahead of Quarto's own `.sidebar-tools-main` rather
-   than relying on stylesheet order. */
+   than relying on stylesheet order.
+
+   The row is also the containing block for the overlay menu below. It spans
+   the sidebar, where the centred trigger does not, so anchoring the menu here
+   is what keeps it inside the column. */
 #quarto-sidebar .gitlink-widget-tools {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -241,9 +246,12 @@
 
 /* The widget sits below the icon tools (colour-scheme and reader toggles) and
    above the search control, whether search is the sidebar field below the row
-   or an overlay button inside it. */
+   or an overlay button inside it. `position: static` hands the menu's
+   containing block up to the row: the widget is `position: relative` by
+   default, which would otherwise anchor the menu to the trigger pill. */
 .gitlink-widget-tools .gitlink-widget {
   order: 1;
+  position: static;
 }
 
 .gitlink-widget-tools #quarto-search {
@@ -252,14 +260,24 @@
 
 /* A tool sits in a strip of icon-sized controls, where an inline menu would
    be laid out as another flex item beside them, so it keeps the overlay menu.
-   The menu is anchored to the trigger's left edge and takes its content width
-   (no 14rem floor) so it stays inside the sidebar, which clips overflow
-   rather than scrolling sideways. */
+
+   Quarto's sidebar does not clip: it sets `overflow-y: auto` and leaves
+   `overflow-x` at `visible`, which computes to `auto`, so a menu wider than
+   the column scrolls it sideways instead. The menu is hidden with
+   `visibility` rather than `display`, so it takes part in layout even while
+   shut and the scrollbar is there before anything is opened.
+
+   Stretching it between both edges of the row (which the rule above made the
+   containing block) is what bounds it: the trigger is centred, so anchoring
+   to the trigger left the menu running past the column's right edge. `width`
+   has to give way with it, since a specified width over-constrains an
+   absolutely positioned box and `right` is the offset that gets dropped, and
+   the 14rem floor has to go for the same reason on a narrow sidebar. */
 .gitlink-widget-tools .gitlink-widget-dropdown {
   left: 0;
-  right: auto;
+  right: 0;
   min-width: 0;
-  width: max-content;
+  width: auto;
 }
 
 /* The collapsed navbar-nav is a Bootstrap `.navbar-nav-scroll` region


### PR DESCRIPTION
## Problem

A docked sidebar carrying the widget in its tools row has a permanent horizontal scrollbar, present before the menu is opened.

Quarto's sidebar sets `overflow-y: auto` and leaves `overflow-x` at `visible`, which per CSS computes to `auto`, so a box wider than the column scrolls it sideways rather than being clipped. `#quarto-sidebar .gitlink-widget-tools` centres the trigger, and the menu was anchored to the trigger's left edge at `width: max-content`, so on a 265px column it started at x=61 and reached x=300. Because the menu is hidden with `visibility` rather than `display`, it takes part in layout while shut and extended the scrollable area on its own.

The comment on that rule asserted the sidebar "clips overflow rather than scrolling sideways". That premise is false, and it is what made anchoring to the trigger look sufficient; it is corrected here along with the rule.

## Fix

Three declarations, all in rule blocks that already existed:

- `#quarto-sidebar .gitlink-widget-tools` gains `position: relative`, making the row the menu's containing block. The row spans the column where the centred trigger does not.
- `.gitlink-widget-tools .gitlink-widget` gains `position: static`, so the widget stops being that containing block.
- `.gitlink-widget-tools .gitlink-widget-dropdown` goes from `right: auto` / `width: max-content` to `right: 0` / `width: auto`. The width has to be released because a specified width over-constrains an absolutely positioned box and `right` is the offset that gets dropped.

## Verification

Measured in headless Chrome on the quarto-atelier site, the one site in the family with no per-repository workaround masking the defect.

| | before | after |
|---|---|---|
| sidebar `clientWidth` / `scrollWidth` | 265 / 300 | 265 / 265 |
| menu left / right | 61 / 300 | 20 / 248 |

The menu still opens and is usable: computed `visibility: visible`, rect 228 x 434, nine items, right edge at 248 inside the 265 column. The collapsed tools row a site with a navbar gets (`.sidebar-tools-collapse`) is fixed the same way: 265 / 265, menu 20 / 265.

No site in this family exercises navbar or `sidebar.contents` placement, so both were checked on a purpose-built minimal site. `widget.js` adds the tools marker class only to a `.sidebar-tools-main` or `.sidebar-tools-collapse` container, and the `sidebar.contents` path is the mutually exclusive `else if`, so neither placement can match the changed selectors. Measured before and after, both are byte-identical: the navbar menu keeps its 14rem floor and its right-edge anchor, and a `sidebar.contents` menu keeps expanding inline (`position: static`, `display: none` to `block`, full width).
