### PR TITLE
chore: sync the shared metadata module

### DIFF
--- a/_extensions/gitlink/_modules/metadata.lua
+++ b/_extensions/gitlink/_modules/metadata.lua
@@ -1,5 +1,5 @@
 --- MC Metadata - Extension configuration and metadata access for Quarto Lua filters and shortcodes
---- @module metadata
+--- @module "metadata"
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil
@@ -42,8 +42,12 @@ end
 --- @param key string The metadata key to retrieve
 --- @return string|nil The metadata value as a string, or nil if not found
 --- @usage local repo = M.get_metadata_value(meta, "github", "repository-name")
+--- @note A boolean `false` is a value, not an absence, so the test is against
+---   `nil` rather than truthiness. Stringifying it yields "false", which is what
+---   a caller comparing against the string form already expects.
 function M.get_metadata_value(meta, extension_name, key)
-  if meta['extensions'] and meta['extensions'][extension_name] and meta['extensions'][extension_name][key] then
+  if meta['extensions'] and meta['extensions'][extension_name]
+      and meta['extensions'][extension_name][key] ~= nil then
     return str.stringify(meta['extensions'][extension_name][key])
   end
   return nil

--- a/_extensions/gitlink/gitlink.lua
+++ b/_extensions/gitlink/gitlink.lua
@@ -109,9 +109,8 @@ local function colour_to_hex(value)
 end
 
 --- Read a boolean metadata value with a default.
---- `get_metadata_value()` returns nil for boolean `false` (its truthy guard
---- treats false as missing), so this helper reads the raw value directly
---- and coerces it via `tostring`.
+--- Reads the raw value rather than going through `get_metadata_value()`, so a
+--- boolean, a quoted string, and a bare YAML `false` all resolve the same way.
 --- @param gitlink_meta table|nil The `extensions.gitlink` metadata sub-table
 --- @param key string The option key
 --- @param default boolean The default when the option is absent


### PR DESCRIPTION
The accessor now reads a boolean `false` as a value rather than as an absence.

This extension already read its boolean options directly rather than through the accessor, so nothing it does changes. The comments explaining why that detour was needed described the old module and have been corrected.