### PR TITLE
fix: declare the filter entry point in the extension manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- fix: Register the filter at `post-quarto` in the extension manifest, so listing `gitlink` under `filters` is enough and the entry point no longer has to be named in project or document YAML. The long form `path`/`at` overrides the entry point of every filter an extension contributes, so it is best avoided.
+- fix: Raise `quarto-required` to `>=1.9.38`, the first version whose `_extension.yml` schema accepts a filter entry point.
+
 ## 1.9.2 (2026-08-01)
 
 ### Documentation

--- a/_extensions/gitlink/_extension.yml
+++ b/_extensions/gitlink/_extension.yml
@@ -1,7 +1,8 @@
 title: gitlink
 author: Mickaël Canouil
 version: 1.9.2
-quarto-required: ">=1.8.21"
+quarto-required: ">=1.9.38"
 contributes:
   filters:
-    - gitlink.lua
+    - path: gitlink.lua
+      at: post-quarto

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -37,8 +37,7 @@ Or install it from your editor with [Quarto Wizard](https://m.canouil.dev/quarto
 
 ```yaml
 filters:
-  - path: gitlink
-    at: post-quarto
+  - gitlink
 extensions:
   gitlink:
     platform: github
@@ -53,9 +52,7 @@ Fixed in #1, see also mcanouil/quarto-gitlink#1.
 
 The repository is detected from the git remote when it is not given.
 
-::: {.callout-important}
-`post-quarto` is required, so Quarto resolves its own cross-references before this filter looks at the text.
-:::
+The extension registers the filter at `post-quarto`, so Quarto resolves its own cross-references before it looks at the text.
 
 See the [Reference](reference.qmd) for every option, and the [Examples](examples.qmd) for the reference forms rendered.
 

--- a/docs/reference.qmd
+++ b/docs/reference.qmd
@@ -8,14 +8,10 @@ description: "The complete gitlink configuration: the platforms, the reference f
 
 ```yaml
 filters:
-  - path: gitlink
-    at: post-quarto
+  - gitlink
 ```
 
-::: {.callout-important}
-`post-quarto` is required.
-Quarto's own cross-references, `@fig-something` among them, have to be resolved before this filter reads the text.
-:::
+The extension registers the filter at `post-quarto`, so Quarto's own cross-references, `@fig-something` among them, are resolved before it reads the text.
 
 ## Options
 

--- a/example.qmd
+++ b/example.qmd
@@ -11,8 +11,7 @@ format:
     toc: true
 # Extension configuration
 filters:
-  - path: gitlink
-    at: post-quarto
+  - gitlink
 extensions:
   gitlink:
     platform: github
@@ -40,8 +39,7 @@ Add the extension to your document's YAML front matter:
 ---
 title: "My Document"
 filters:
-  - path: gitlink
-    at: post-quarto
+  - gitlink
 extensions:
   gitlink:
     platform: github               # Platform: github, gitlab, codeberg, gitea, bitbucket


### PR DESCRIPTION
The extension manifest now registers the filter at `post-quarto`, so listing `gitlink` under `filters` is enough and the entry point no longer has to be repeated in project or document YAML. The documentation and `example.qmd` use the short form throughout.

`quarto-required` moves to >=1.9.38, the first version whose `_extension.yml` schema accepts a filter entry point. Below it the render fails validation.