### PR TITLE
refactor: rename schema module to platform-schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Bug Fixes
 
-- fix: Load the `string` module by its own path in the Bitbucket module, so another extension's module cannot be used instead.
+- fix: Load the `string` module by its own path in the Bitbucket module, so another extension's module cannot be used instead. (#57)
 
 ### Refactoring
 
-- refactor: Rename the platform validation module to `platform-schema`, freeing the shared `schema` module name.
+- refactor: Rename the platform validation module to `platform-schema`, freeing the shared `schema` module name. (#57)
 
 ## 1.10.0 (2026-08-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Refactoring
+
+- refactor: Rename the platform validation module to `platform-schema`, freeing the shared `schema` module name.
+
 ## 1.10.0 (2026-08-01)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- fix: Load the `string` module by its own path in the Bitbucket module, so another extension's module cannot be used instead.
+
 ### Refactoring
 
 - refactor: Rename the platform validation module to `platform-schema`, freeing the shared `schema` module name.

--- a/_extensions/gitlink/_modules/bitbucket.lua
+++ b/_extensions/gitlink/_modules/bitbucket.lua
@@ -4,7 +4,16 @@
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil
 
-local str = require("_modules/string")
+--- Load a sibling module from the same directory as this file.
+--- @param filename string The sibling module filename (e.g., 'string.lua')
+--- @return table The loaded module
+local function load_sibling(filename)
+  local source = debug.getinfo(1, 'S').source:sub(2)
+  local dir = source:match('(.*[/\\])') or ''
+  return require((dir .. filename):gsub('%.lua$', ''))
+end
+
+local str = load_sibling('string.lua')
 
 local bitbucket_module = {}
 

--- a/_extensions/gitlink/_modules/platform-schema.lua
+++ b/_extensions/gitlink/_modules/platform-schema.lua
@@ -1,10 +1,10 @@
---- Schema Validation Module
---- @module "schema"
+--- MC Platform Schema - Validator for gitlink platform configurations (platforms.yml)
+--- @module "platform-schema"
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil
 
-local schema_module = {}
+local platform_schema = {}
 
 -- ============================================================================
 -- CONSTANTS
@@ -298,13 +298,13 @@ end
 --- @param config table The platform configuration to validate
 --- @return ValidationResult
 --- @usage
----   local result = schema_module.validate_platform('github', config)
+---   local result = platform_schema.validate_platform('github', config)
 ---   if not result.valid then
 ---     for _, err in ipairs(result.errors) do
 ---       print('ERROR: ' .. err)
 ---     end
 ---   end
-function schema_module.validate_platform(platform_name, config)
+function platform_schema.validate_platform(platform_name, config)
   local result = create_validation_result()
 
   if not is_string(platform_name) or platform_name == '' then
@@ -337,8 +337,8 @@ end
 --- @param platforms table Table of platform configurations keyed by name
 --- @return table<string, ValidationResult> Validation results for each platform
 --- @usage
----   local results = schema_module.validate_all_platforms(platforms_config)
-function schema_module.validate_all_platforms(platforms)
+---   local results = platform_schema.validate_all_platforms(platforms_config)
+function platform_schema.validate_all_platforms(platforms)
   local results = {}
 
   if not is_table(platforms) then
@@ -348,7 +348,7 @@ function schema_module.validate_all_platforms(platforms)
   end
 
   for platform_name, config in pairs(platforms) do
-    results[platform_name] = schema_module.validate_platform(platform_name, config)
+    results[platform_name] = platform_schema.validate_platform(platform_name, config)
   end
 
   return results
@@ -358,9 +358,9 @@ end
 --- @param result ValidationResult The validation result to format
 --- @return string, string|nil Formatted message, and platform_name if provided
 --- @usage
----   local msg = schema_module.format_result(result)
+---   local msg = platform_schema.format_result(result)
 ---   print(msg)
-function schema_module.format_result(result)
+function platform_schema.format_result(result)
   local lines = {}
 
   if result.valid then
@@ -395,8 +395,8 @@ end
 --- @param result ValidationResult The validation result
 --- @return string Summary string
 --- @usage
----   local summary = schema_module.get_summary(result)
-function schema_module.get_summary(result)
+---   local summary = platform_schema.get_summary(result)
+function platform_schema.get_summary(result)
   return string.format(
     'Status: %s | Errors: %d | Warnings: %d',
     result.valid and 'PASSED' or 'FAILED',
@@ -409,4 +409,4 @@ end
 -- MODULE EXPORT
 -- ============================================================================
 
-return schema_module
+return platform_schema

--- a/_extensions/gitlink/_modules/platforms.lua
+++ b/_extensions/gitlink/_modules/platforms.lua
@@ -6,8 +6,8 @@
 
 local platforms_module = {}
 
--- Load schema validation module
-local schema = require(quarto.utils.resolve_path('_modules/schema.lua'):gsub('%.lua$', ''))
+-- Load platform schema validation module
+local platform_schema = require(quarto.utils.resolve_path('_modules/platform-schema.lua'):gsub('%.lua$', ''))
 
 -- ============================================================================
 -- CONFIGURATION STORAGE
@@ -112,7 +112,7 @@ function platforms_module.initialise(yaml_path)
     return false, msg
   end
 
-  local validation_results_all = schema.validate_all_platforms(loaded_configs)
+  local validation_results_all = platform_schema.validate_all_platforms(loaded_configs)
   local has_errors = false
   local error_messages = {}
 
@@ -221,7 +221,7 @@ function platforms_module.register_custom_platform(platform_name, config)
     return false, 'Platform name and configuration are required'
   end
 
-  local result = schema.validate_platform(platform_name, config)
+  local result = platform_schema.validate_platform(platform_name, config)
 
   if not result.valid then
     local error_lines = {}
@@ -303,7 +303,7 @@ end
 ---   local result = platforms_module.validate_platform_config('forgejo', config)
 ---   if result.valid then print('OK') else print(table.concat(result.errors, ', ')) end
 function platforms_module.validate_platform_config(platform_name, config)
-  return schema.validate_platform(platform_name, config)
+  return platform_schema.validate_platform(platform_name, config)
 end
 
 --- Validate all platforms in a configuration table
@@ -313,7 +313,7 @@ end
 --- @usage
 ---   local results = platforms_module.validate_all_platforms(platforms_config)
 function platforms_module.validate_all_platforms(platforms)
-  return schema.validate_all_platforms(platforms)
+  return platform_schema.validate_all_platforms(platforms)
 end
 
 -- ============================================================================


### PR DESCRIPTION
`_modules/schema.lua` in this extension validates platform configurations from `platforms.yml`. That filename is already claimed by the shared `schema.lua` module, which validates an extension's `_schema.yml` against the v2 meta-schema. Two files cannot share a name in `_modules/`, so gitlink could not carry both. The file is now `_modules/platform-schema.lua`, with its module table renamed to match, and `_modules/platforms.lua` updated to load it.

Also fixes how `_modules/bitbucket.lua` loads the shared `string` module. It used `require("_modules/string")`, a bare module name. Quarto's patched `require` rewrites a name to a fully qualified path only when the name starts with `.`, so this one was cached under that literal key, which is global to the render. Another extension's `_modules/string` could be returned in its place. It now uses the same `load_sibling` helper as `paths.lua`, `metadata.lua`, `html.lua`, and `widget.lua`.

Verified by rendering `example.qmd`, a Bitbucket document, a document with an invalid custom platform file (the validator still reports the platform name and the missing field), and the `docs/` site.